### PR TITLE
fix: Remove complexity calculations from the output

### DIFF
--- a/src/rules/E009.rs
+++ b/src/rules/E009.rs
@@ -84,7 +84,6 @@ impl Rule for E009 {
                                         &mut graph,
                                     );
 
-                                    println!("{}", graph.calculate());
                                     if graph.calculate() > 10 {
                                         suggestions.push(Suggestion::from(
                             "This method body is too complex. Make it easier to understand."


### PR DESCRIPTION
Removes complexity calculations results from outpur
```

Warnings detected:  1
  E008:	The buildLabelOption has a return statement but it has no return type signature.
  148:9	|         return t($label, $field->getTranslationParameters(), $translationDomain);


2
1
0
0
0
0
0
0
0
0
0
0
2
0
0
0
Warnings detected:  1
  E002:	There is an empty catch. It's not recommended to catch an Exception without doing anything with it..
  140:15	|             } catch (\Throwable) {



```
=>
```

Warnings detected:  1
  E008:	The buildLabelOption has a return statement but it has no return type signature.
  148:9	|         return t($label, $field->getTranslationParameters(), $translationDomain);


Warnings detected:  1
  E002:	There is an empty catch. It's not recommended to catch an Exception without doing anything with it..
  140:15	|             } catch (\Throwable) {



```