### PR TITLE
feat: Output formats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
+name = "cli-table"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adfbb116d9e2c4be7011360d0c0bee565712c11e969c9609b25b619366dc379d"
+dependencies = [
+ "cli-table-derive",
+ "csv",
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "cli-table-derive"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af3bfb9da627b0a6c467624fb7963921433774ed435493b5c08a3053e829ad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +305,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "csv"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -647,6 +691,7 @@ version = "0.1.1"
 dependencies = [
  "bindgen",
  "clap",
+ "cli-table",
  "colored",
  "jwalk",
  "lsp-server",
@@ -959,6 +1004,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1023,6 +1077,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.1.4", features = ["derive"] }
+cli-table = "0.4.7"
 colored = "2.0.0"
 jwalk = "0.8.1"
 lsp-server = "0.7.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,21 +7,12 @@ use serde_json::Value as JsonValue;
 
 use crate::rules;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[allow(clippy::upper_case_acronyms)]
-pub enum Output {
-    STDOUT,
-    FILE,
-}
-
 #[derive(Serialize, Debug, Deserialize, Clone)]
 pub struct Config {
     pub src: String,
-    pub storage: String,
     pub enabled_rules: Vec<String>,
     pub disable_rules: Vec<String>,
     pub rules: HashMap<String, JsonValue>,
-    pub output: Output,
 }
 
 impl Default for Config {
@@ -40,8 +31,6 @@ impl Default for Config {
             enabled_rules,
             disable_rules,
             rules,
-            storage: String::from("/tmp/phanalist"),
-            output: Output::STDOUT,
         }
     }
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,0 +1,106 @@
+use std::path::PathBuf;
+
+use php_parser_rs::parser;
+use php_parser_rs::parser::ast::classes::ClassStatement;
+use php_parser_rs::parser::ast::Statement;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct File {
+    pub path: PathBuf,
+    pub content: String,
+    #[serde(skip_serializing, skip_deserializing)]
+    pub ast: Vec<Statement>,
+}
+
+impl File {
+    fn get_namespace(&self) -> Option<String> {
+        let mut namespace: Option<String> = None;
+        self.ast.iter().for_each(|statement| {
+            namespace = match statement {
+                Statement::Namespace(parser::ast::namespaces::NamespaceStatement::Braced(n)) => {
+                    if n.name.is_some() {
+                        Some(n.name.clone().unwrap().value.to_string())
+                    } else {
+                        None
+                    }
+                }
+                Statement::Namespace(parser::ast::namespaces::NamespaceStatement::Unbraced(n)) => {
+                    Some(n.name.to_string())
+                }
+                _ => None,
+            };
+        });
+        namespace
+    }
+
+    fn get_class_name(&self) -> Option<String> {
+        let mut class_name: Option<String> = None;
+        for statement in &self.ast {
+            if class_name.is_none() {
+                match statement {
+                    Statement::Namespace(parser::ast::namespaces::NamespaceStatement::Braced(
+                        n,
+                    )) => {
+                        for statement in &n.body.statements {
+                            if let Statement::Class(ClassStatement {
+                                attributes: _,
+                                modifiers: _,
+                                class: _,
+                                name,
+                                extends: _,
+                                implements: _,
+                                body: _,
+                            }) = statement
+                            {
+                                class_name = Some(name.value.to_string());
+                            }
+                        }
+                    }
+                    Statement::Namespace(
+                        parser::ast::namespaces::NamespaceStatement::Unbraced(n),
+                    ) => {
+                        for statement in &n.statements {
+                            if let Statement::Class(ClassStatement {
+                                attributes: _,
+                                modifiers: _,
+                                class: _,
+                                name,
+                                extends: _,
+                                implements: _,
+                                body: _,
+                            }) = statement
+                            {
+                                class_name = Some(name.value.to_string());
+                            }
+                        }
+                    }
+                    _ => {}
+                };
+                if let Statement::Class(ClassStatement {
+                    attributes: _,
+                    modifiers: _,
+                    class: _,
+                    name,
+                    extends: _,
+                    implements: _,
+                    body: _,
+                }) = statement
+                {
+                    class_name = Some(name.value.to_string());
+                }
+            }
+        }
+        class_name
+    }
+
+    pub fn get_fully_qualified_name(&self) -> Option<String> {
+        match self.get_namespace() {
+            Some(n) => {
+                let option = self.get_class_name();
+                option.map(|s| format!("{}\\{}", n, s))
+            }
+            None => self.get_class_name(),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,23 @@
-use clap::Parser;
-use project::Project;
+use std::fs;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use clap::Parser;
+
+use project::Project;
+
+use crate::config::Config;
+use crate::output::Format;
 
 mod analyse;
 mod config;
+mod file;
 mod language_server_protocol;
+mod output;
 mod project;
+mod results;
 mod rules;
-mod storage;
 
 ///
 /// A static analyser for your PHP project.
@@ -18,6 +28,11 @@ struct Args {
     config: String,
     #[arg(short, long, default_value = "./src")]
     src: Option<String>,
+    #[arg(short, long, default_value = "text")]
+    /// Possible options: text, json
+    output_format: String,
+    #[arg(long)]
+    output_summary_only: bool,
     /// Start the LSP server.
     #[arg(long)]
     deamon: bool,
@@ -29,17 +44,69 @@ fn main() {
     if args.deamon {
         language_server_protocol::start();
     } else {
-        let config = PathBuf::from(args.config);
-        let mut project = Project::new(config, args.src);
-
-        if !Path::new(project.config.src.as_str()).exists() {
-            println!("Path {} does not exist", project.config.src);
+        let output_format = output::Format::from_str(args.output_format.as_str());
+        if output_format.is_err() {
+            println!("Invalid input format");
             return;
         }
 
-        let now = std::time::Instant::now();
-        let files = project.scan();
-        project.run();
-        println!("Analysed {} files in : {:.2?}", files, now.elapsed());
+        let format = output_format.clone().unwrap();
+        let mut config = parse_config(PathBuf::from(args.config), format.clone());
+        if let Some(src) = args.src {
+            config.src = src;
+        }
+
+        if !Path::new(config.src.as_str()).exists() {
+            println!("Path {} does not exist", config.src);
+            return;
+        }
+
+        let mut project = Project::new(config);
+
+        project.scan();
+        project.output(output_format.unwrap(), args.output_summary_only);
+    }
+}
+
+fn parse_config(path: PathBuf, format: Format) -> Config {
+    let default_config = Config::default();
+
+    match fs::read_to_string(path.clone()) {
+        Err(e) if e.kind() == ErrorKind::NotFound => {
+            println!(
+                "No configuration file {} has been found.",
+                &path.clone().display()
+            );
+            println!("Do you want to create a configuration file (otherwise defaults will be used)? [Y/n]");
+
+            let mut answer = String::new();
+            std::io::stdin().read_line(&mut answer).unwrap();
+
+            if answer.trim().to_lowercase() == "y" || answer.trim().to_lowercase() == "yes" {
+                default_config.save(path.clone());
+                println!(
+                    "The new {} configuration file as been created",
+                    &path.display()
+                );
+            };
+
+            default_config
+        }
+
+        Err(e) => {
+            panic!("{}", e)
+        }
+        Ok(s) => {
+            if format == Format::text {
+                println!("Using configuration file {}", &path.display());
+            }
+            match serde_yaml::from_str(&s) {
+                Ok(c) => c,
+                Err(e) => {
+                    println!("Unable to use the config: {}. Ignoring it.", &e);
+                    default_config
+                }
+            }
+        }
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,0 +1,104 @@
+use std::str::FromStr;
+
+use colored::Colorize;
+use serde::{Deserialize, Serialize};
+
+use cli_table::{format::Justify, Cell, Style, Table};
+
+use crate::results::Results;
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[allow(non_camel_case_types)]
+
+pub enum Format {
+    text,
+    json,
+}
+
+impl FromStr for Format {
+    type Err = ();
+
+    fn from_str(input: &str) -> Result<Format, Self::Err> {
+        match input {
+            "text" => Ok(Format::text),
+            "json" => Ok(Format::json),
+            _ => Err(()),
+        }
+    }
+}
+
+pub(crate) trait OutputFormatter {
+    fn output(_results: Results) {}
+}
+
+pub struct Text {}
+impl OutputFormatter for Text {
+    fn output(results: Results) {
+        for (path, violations) in results.files.clone() {
+            if !violations.is_empty() {
+                let file_symbol = "--->".blue().bold();
+                println!("{} {} ", file_symbol, path);
+                println!(
+                    "{} {}",
+                    "Warnings detected: ".yellow().bold(),
+                    violations.len().to_string().as_str().red().bold()
+                );
+                let line_symbol = "|".blue().bold();
+                for suggestion in &violations {
+                    println!(
+                        "  {}:\t{}",
+                        suggestion.rule.yellow().bold(),
+                        suggestion.suggestion.bold()
+                    );
+                    println!(
+                        "  {}\t{} {}",
+                        format!("{}:{}", suggestion.span.line, suggestion.span.column)
+                            .blue()
+                            .bold(),
+                        line_symbol,
+                        suggestion.line
+                    );
+                    println!();
+                }
+                println!()
+            }
+        }
+
+        let mut rows = vec![];
+        for (rule_code, violations) in results.codes_count {
+            rows.push(vec![
+                rule_code.as_str().cell(),
+                violations.cell().justify(Justify::Right),
+            ]);
+        }
+        let table = rows
+            .table()
+            .title(vec![
+                "Rule Code".cell().bold(true),
+                "Violations".cell().bold(true),
+            ])
+            .bold(true);
+        println!("{}", table.display().unwrap());
+
+        println!(
+            "Analysed {} files in : {:.2?}",
+            results.total_files_count,
+            results.duration.unwrap()
+        );
+    }
+}
+
+pub struct Json {}
+impl OutputFormatter for Json {
+    fn output(results: Results) {
+        let mut output_results = results.clone();
+
+        for (path, violations) in output_results.files.clone() {
+            if violations.is_empty() {
+                output_results.files.remove(&path);
+            }
+        }
+
+        println!("{}", serde_json::to_string_pretty(&output_results).unwrap());
+    }
+}

--- a/src/project.rs
+++ b/src/project.rs
@@ -1,36 +1,26 @@
 use std::collections::HashMap;
-use std::default::Default;
 use std::fs;
-use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::sync::mpsc::Sender;
 
-use colored::*;
 use jwalk::WalkDir;
-use php_parser_rs::lexer::token::Span;
 use php_parser_rs::parser;
-use php_parser_rs::parser::ast::classes::{ClassMember, ClassStatement};
-use php_parser_rs::parser::ast::functions::ConcreteMethod;
-use php_parser_rs::parser::ast::namespaces::{NamespaceStatement, UnbracedNamespace};
-use php_parser_rs::parser::ast::Statement;
-use rocksdb::{IteratorMode, DB};
-use serde::{Deserialize, Serialize};
+use php_parser_rs::parser::ast::classes::ClassStatement;
 
 use crate::analyse::Analyse;
-use crate::config::{Config, Output};
-use crate::storage;
+use crate::config::Config;
+use crate::file::File;
+use crate::output::{Format, Json, OutputFormatter, Text};
+use crate::results::Results;
 
 pub struct Project {
     pub files: Vec<File>,
     pub classes: HashMap<String, ClassStatement>,
     pub config: Config,
-    db: Option<DB>,
-    analyse: Option<Analyse>,
+    analyse: Analyse,
+    results: Results,
 }
 
-// Scan a directory and find all php files. When a
-// file has been found the content of the file will be sent to
-// as a message to the receiver.
 pub fn scan_folder(current_dir: PathBuf, sender: Sender<(String, PathBuf)>) {
     for entry in WalkDir::new(current_dir.clone()).follow_links(false) {
         let entry = entry.unwrap();
@@ -59,366 +49,61 @@ pub fn scan_folder(current_dir: PathBuf, sender: Sender<(String, PathBuf)>) {
 }
 
 impl Project {
-    pub fn new(config_path: PathBuf, src: Option<String>) -> Self {
-        let mut project = Self {
+    pub fn new(config: Config) -> Self {
+        Self {
             files: Vec::new(),
             classes: HashMap::new(),
-            config: Config::default(),
-            db: None,
-            analyse: None,
-        };
-        project.parse_config(config_path);
-
-        if let Some(src) = src {
-            project.config.src = src;
-        }
-
-        let file_path = project.config.storage.clone();
-        let file = std::path::Path::new(&file_path);
-
-        if file.is_dir() {
-            let _ = fs::remove_dir_all(file);
-        }
-        project.db = Some(DB::open_default(&project.config.storage).unwrap());
-
-        project.analyse = Some(Analyse::new(project.config.clone()));
-
-        project
-    }
-    /// Iterate over the list of files and analyse the code.
-    pub fn run(&mut self) {
-        let db = self.db.as_mut().unwrap();
-        let iter = db.iterator(IteratorMode::Start);
-        for i in iter {
-            let item = i.unwrap();
-            let file = item.1;
-
-            match serde_json::from_slice::<File>(&file) {
-                Err(e) => {
-                    println!("{e}");
-                }
-                Ok(mut f) => {
-                    f.ast = parse_code(f.content.as_str()).unwrap();
-                    Self::analyze(f, self.analyse.as_ref().unwrap());
-                }
-            };
+            config: config.clone(),
+            analyse: Analyse::new(config.clone()),
+            results: Results::default(),
         }
     }
 
-    pub fn scan(&self) -> i64 {
+    pub fn scan(&mut self) {
+        let now = std::time::Instant::now();
+
         let (send, recv) = std::sync::mpsc::channel();
         let path = self.config.src.clone();
         std::thread::spawn(move || {
             let path = PathBuf::from(path);
             self::scan_folder(path, send);
         });
-        let file_path = self.config.storage.clone();
-        let file = std::path::Path::new(&file_path);
 
-        if file.is_dir() {
-            let _ = fs::remove_dir_all(file);
-        }
-
-        let db = self.db.as_ref().unwrap();
         let mut files = 0;
         for (content, path) in recv {
-            let ast = parse_code(&content).unwrap();
-            let file = &mut File {
+            let ast = match parser::parse(&content) {
+                Ok(a) => a,
+                Err(_) => vec![],
+            };
+            let file = File {
                 content,
                 path: path.clone(),
                 ast: ast.clone(),
-                members: Vec::new(),
-                methods: Vec::new(),
-                suggestions: Vec::new(),
             };
 
-            file.build_metadata();
-            if let Some(fqn) = file.get_fully_qualified_name() {
-                storage::put(db, fqn, file.clone());
+            if file.get_fully_qualified_name().is_some() {
+                for statement in file.ast.clone() {
+                    self.results
+                        .add_file_violations(&file, self.analyse.analyse(&file, statement));
+                }
+
                 files += 1;
             };
         }
-        files
+
+        self.results.total_files_count = files;
+        self.results.duration = Some(now.elapsed());
     }
 
-    /// Parse the configuration yaml file.
-    /// If there is no configuration file, create a new new one.
-    pub fn parse_config(&mut self, path: PathBuf) {
-        match fs::read_to_string(path.clone()) {
-            Err(e) if e.kind() == ErrorKind::NotFound => {
-                println!(
-                    "No configuration file {} has been found.",
-                    &path.clone().display()
-                );
-                println!("Do you want to create a configuration file (otherwise defaults will be used)? [Y/n]");
-
-                let mut answer = String::new();
-                std::io::stdin().read_line(&mut answer).unwrap();
-
-                if answer.trim().to_lowercase() == "y" || answer.trim().to_lowercase() == "yes" {
-                    self.config.save(path.clone());
-                    println!(
-                        "The new {} configuration file as been created",
-                        &path.display()
-                    );
-                };
-            }
-
-            Err(e) => {
-                panic!("{}", e)
-            }
-            Ok(s) => {
-                println!("Using configuration file {}", &path.display());
-                match serde_yaml::from_str(&s) {
-                    Ok(c) => {
-                        self.config = c;
-                    }
-                    Err(e) => {
-                        println!("Unable to use the config: {}. Ignoring it.", &e);
-                    }
-                }
-            }
+    pub fn output(&mut self, format: Format, summary_only: bool) {
+        let mut output_results = self.results.clone();
+        if summary_only {
+            output_results.files = HashMap::new();
         };
-    }
 
-    pub fn analyze(mut file: File, analyse: &Analyse) -> Vec<Suggestion> {
-        for statement in file.ast.clone() {
-            let suggestions = analyse.statement(statement);
-            for suggestion in suggestions {
-                file.suggestions.push(suggestion);
-            }
-        }
-        file.output(Output::STDOUT);
-        file.suggestions
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct Suggestion {
-    rule: String,
-    suggestion: String,
-    span: Span,
-}
-
-impl Suggestion {
-    pub fn from(suggesion: String, span: Span, rule: String) -> Self {
-        Self {
-            rule,
-            suggestion: suggesion,
-            span,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct File {
-    pub path: PathBuf,
-
-    pub content: String,
-
-    #[serde(skip_serializing, skip_deserializing)]
-    pub ast: Vec<Statement>,
-
-    pub members: Vec<ClassMember>,
-
-    #[serde(skip_serializing, skip_deserializing)]
-    pub suggestions: Vec<Suggestion>,
-
-    pub methods: Vec<ConcreteMethod>,
-}
-
-impl File {
-    /// Build metadata public methods, variables, contstants, etc.
-    /// @todo add properties and constants.
-    pub fn build_metadata(&mut self) {
-        self.ast.iter().for_each(|statement| {
-            if let Statement::Namespace(NamespaceStatement::Unbraced(UnbracedNamespace {
-                start: _,
-                name: _,
-                end: _,
-                statements,
-            })) = statement
-            {
-                statements.iter().for_each(|statement| {
-                    if let Statement::Class(ClassStatement {
-                        attributes: _,
-                        modifiers: _,
-                        class: _,
-                        name: _,
-                        extends: _,
-                        implements: _,
-                        body,
-                    }) = statement
-                    {
-                        for member in &body.members {
-                            if let php_parser_rs::parser::ast::classes::ClassMember::ConcreteMethod(
-                                _concrete_method,
-                            ) = member {
-                                self.members.push(member.clone());
-                            };
-                        }
-                    };
-                })
-            };
-
-            if let Statement::Class(ClassStatement {
-                attributes: _,
-                modifiers: _,
-                class: _,
-                name: _,
-                extends: _,
-                implements: _,
-                body,
-            }) = statement
-            {
-                for member in &body.members {
-                    if let php_parser_rs::parser::ast::classes::ClassMember::ConcreteMethod(
-                        _concrete_method,
-                    ) = member
-                    {
-                        self.members.push(member.clone());
-                    };
-                }
-            };
-        });
-    }
-
-    /// Return the namespace of the statement.
-    fn get_namespace(&self) -> Option<String> {
-        let mut namespace: Option<String> = None;
-        self.ast.iter().for_each(|statement| {
-            namespace = match statement {
-                Statement::Namespace(parser::ast::namespaces::NamespaceStatement::Braced(n)) => {
-                    if n.name.is_some() {
-                        Some(n.name.clone().unwrap().value.to_string())
-                    } else {
-                        None
-                    }
-                }
-                Statement::Namespace(parser::ast::namespaces::NamespaceStatement::Unbraced(n)) => {
-                    Some(n.name.to_string())
-                }
-                _ => None,
-            };
-        });
-        namespace
-    }
-
-    /// Get the class name inside a method body
-    fn get_class_name(&self) -> Option<String> {
-        let mut class_name: Option<String> = None;
-        for statement in &self.ast {
-            if class_name.is_none() {
-                match statement {
-                    Statement::Namespace(parser::ast::namespaces::NamespaceStatement::Braced(
-                        n,
-                    )) => {
-                        for statement in &n.body.statements {
-                            if let Statement::Class(ClassStatement {
-                                attributes: _,
-                                modifiers: _,
-                                class: _,
-                                name,
-                                extends: _,
-                                implements: _,
-                                body: _,
-                            }) = statement
-                            {
-                                class_name = Some(name.value.to_string());
-                            }
-                        }
-                    }
-                    Statement::Namespace(
-                        parser::ast::namespaces::NamespaceStatement::Unbraced(n),
-                    ) => {
-                        for statement in &n.statements {
-                            if let Statement::Class(ClassStatement {
-                                attributes: _,
-                                modifiers: _,
-                                class: _,
-                                name,
-                                extends: _,
-                                implements: _,
-                                body: _,
-                            }) = statement
-                            {
-                                class_name = Some(name.value.to_string());
-                            }
-                        }
-                    }
-                    _ => {}
-                };
-                if let Statement::Class(ClassStatement {
-                    attributes: _,
-                    modifiers: _,
-                    class: _,
-                    name,
-                    extends: _,
-                    implements: _,
-                    body: _,
-                }) = statement
-                {
-                    class_name = Some(name.value.to_string());
-                }
-            }
-        }
-        class_name
-    }
-
-    pub fn get_fully_qualified_name(&self) -> Option<String> {
-        match self.get_namespace() {
-            Some(n) => {
-                let option = self.get_class_name();
-                option.map(|s| format!("{}\\{}", n, s))
-            }
-            None => self.get_class_name(),
-        }
-    }
-
-    pub fn output(&mut self, location: Output) {
-        match location {
-            Output::STDOUT => {
-                if !self.suggestions.is_empty() {
-                    let file_symbol = "--->".blue().bold();
-                    println!("{} {} ", file_symbol, self.path.display());
-                    println!(
-                        "{} {}",
-                        "Warnings detected: ".yellow().bold(),
-                        self.suggestions.len().to_string().as_str().red().bold()
-                    );
-                    let line_symbol = "|".blue().bold();
-                    for suggestion in &self.suggestions {
-                        println!(
-                            "  {}:\t{}",
-                            suggestion.rule.yellow().bold(),
-                            suggestion.suggestion.bold()
-                        );
-                        for (i, line) in self.content.lines().enumerate() {
-                            if i == suggestion.span.line - 1 {
-                                println!(
-                                    "  {}\t{} {}",
-                                    format!("{}:{}", suggestion.span.line, suggestion.span.column)
-                                        .blue()
-                                        .bold(),
-                                    line_symbol,
-                                    line
-                                );
-                            }
-                        }
-                        println!();
-                    }
-                    println!()
-                }
-            }
-            Output::FILE => {}
-        }
-    }
-}
-
-/// Parse the code and generate an ast.
-pub fn parse_code(code: &str) -> Option<Vec<php_parser_rs::parser::ast::Statement>> {
-    match parser::parse(code) {
-        Ok(a) => Some(a),
-        Err(_) => Some(vec![]),
+        match format {
+            Format::json => Json::output(output_results),
+            _ => Text::output(output_results),
+        };
     }
 }

--- a/src/results.rs
+++ b/src/results.rs
@@ -1,0 +1,50 @@
+use std::collections::HashMap;
+use std::time::Duration;
+
+use php_parser_rs::lexer::token::Span;
+use serde::{Deserialize, Serialize};
+
+use crate::file::File;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Violation {
+    pub rule: String,
+    pub line: String,
+    pub suggestion: String,
+    pub span: Span,
+}
+
+#[derive(Serialize, Debug, Deserialize, Clone, Default)]
+pub struct Results {
+    pub files: HashMap<String, Vec<Violation>>,
+    pub codes_count: HashMap<String, i64>,
+    pub total_files_count: i64,
+    pub duration: Option<Duration>,
+}
+
+impl Results {
+    pub fn add_file_violations(&mut self, file: &File, violations: Vec<Violation>) {
+        let path = file.path.display().to_string();
+
+        let mut current_file_violations = if let Some(s) = self.files.get(&path) {
+            s.to_owned()
+        } else {
+            vec![]
+        };
+
+        for violation in violations {
+            current_file_violations.push(violation.clone());
+
+            let mut rule_count = if let Some(count) = self.codes_count.get(&violation.rule) {
+                count.to_owned()
+            } else {
+                0
+            };
+            rule_count += 1;
+
+            self.codes_count.insert(violation.rule, rule_count);
+        }
+
+        self.files.insert(path, current_file_violations);
+    }
+}

--- a/src/rules/e1.rs
+++ b/src/rules/e1.rs
@@ -1,6 +1,7 @@
 use php_parser_rs::parser::ast::Statement;
 
-use crate::project::Suggestion;
+use crate::file::File;
+use crate::results::Violation;
 
 pub struct Rule {}
 
@@ -9,54 +10,36 @@ impl crate::rules::Rule for Rule {
         String::from("E0001")
     }
 
-    fn validate(&self, statement: &Statement) -> Vec<Suggestion> {
+    fn validate(&self, file: &File, statement: &Statement) -> Vec<Violation> {
         match statement {
             Statement::FullOpeningTag(tag) => {
                 let span = tag.span;
                 if span.line > 1 {
-                    return vec![
-                        Suggestion::from(
-                            "The opening tag <?php is not on the right line. This should always be the first line in a PHP file.".to_string(),
-                            span,
-                            self.get_code()
-                        )
-                    ];
+                    let suggestion= String::from("The opening tag <?php is not on the right line. This should always be the first line in a PHP file.");
+                    return vec![self.new_violation(file, suggestion, span)];
                 }
 
                 if span.column > 1 {
-                    return vec![Suggestion::from(
-                        format!(
-                            "The opening tag doesn't start at the right column: {}.",
-                            span.column
-                        )
-                        .to_string(),
-                        span,
-                        self.get_code(),
-                    )];
+                    let suggestion = format!(
+                        "The opening tag doesn't start at the right column: {}.",
+                        span.column
+                    );
+                    return vec![self.new_violation(file, suggestion, span)];
                 }
             }
             Statement::ShortOpeningTag(tag) => {
                 let span = tag.span;
                 if span.line > 1 {
-                    return vec![
-                        Suggestion::from(
-                            "The opening tag <?php is not on the right line. This should always be the first line in a PHP file.".to_string(),
-                            span,
-                            self.get_code()
-                        )
-                    ];
+                    let suggestion = String::from("The opening tag <?php is not on the right line. This should always be the first line in a PHP file.");
+                    return vec![self.new_violation(file, suggestion, span)];
                 }
 
                 if span.column > 1 {
-                    return vec![Suggestion::from(
-                        format!(
-                            "The opening tag doesn't start at the right column: {}.",
-                            span.column
-                        )
-                        .to_string(),
-                        span,
-                        self.get_code(),
-                    )];
+                    let suggestion = format!(
+                        "The opening tag doesn't start at the right column: {}.",
+                        span.column
+                    );
+                    return vec![self.new_violation(file, suggestion, span)];
                 }
             }
 

--- a/src/rules/e10.rs
+++ b/src/rules/e10.rs
@@ -1,4 +1,7 @@
-use php_parser_rs::parser::ast::{MethodCallExpression, NewExpression};
+use php_parser_rs::parser::ast::{Expression, MethodCallExpression, NewExpression, Statement};
+
+use crate::file::File;
+use crate::results::Violation;
 
 pub struct Rule {}
 
@@ -7,26 +10,21 @@ impl crate::rules::Rule for Rule {
         String::from("E0010")
     }
 
-    fn validate(
-        &self,
-        statement: &php_parser_rs::parser::ast::Statement,
-    ) -> Vec<crate::project::Suggestion> {
-        if let php_parser_rs::parser::ast::Statement::Expression(expression_statement) = statement {
+    fn validate(&self, _file: &File, statement: &Statement) -> Vec<Violation> {
+        if let Statement::Expression(expression_statement) = statement {
             let _class_name_target = match &expression_statement.expression {
-                php_parser_rs::parser::ast::Expression::AssignmentOperation(assign) => {
-                    match assign.right() {
-                        php_parser_rs::parser::ast::Expression::New(NewExpression {
-                            new: _,
-                            target,
-                            arguments: _,
-                        }) => Some(target),
-                        _ => None,
-                    }
-                }
+                Expression::AssignmentOperation(assign) => match assign.right() {
+                    Expression::New(NewExpression {
+                        new: _,
+                        target,
+                        arguments: _,
+                    }) => Some(target),
+                    _ => None,
+                },
                 _ => None,
             };
 
-            if let php_parser_rs::parser::ast::Expression::MethodCall(MethodCallExpression {
+            if let Expression::MethodCall(MethodCallExpression {
                 target: _,
                 arrow: _,
                 method: _,

--- a/src/rules/e11.rs
+++ b/src/rules/e11.rs
@@ -1,3 +1,8 @@
+use php_parser_rs::parser::ast::Statement;
+
+use crate::file::File;
+use crate::results::Violation;
+
 pub struct Rule {}
 
 impl crate::rules::Rule for Rule {
@@ -5,10 +10,7 @@ impl crate::rules::Rule for Rule {
         String::from("E0011")
     }
 
-    fn validate(
-        &self,
-        _statement: &php_parser_rs::parser::ast::Statement,
-    ) -> Vec<crate::project::Suggestion> {
+    fn validate(&self, _file: &File, _statement: &Statement) -> Vec<Violation> {
         vec![]
     }
 }

--- a/src/rules/e2.rs
+++ b/src/rules/e2.rs
@@ -1,7 +1,8 @@
 use php_parser_rs::parser::ast::try_block::CatchBlock;
 use php_parser_rs::parser::ast::Statement;
 
-use crate::project::Suggestion;
+use crate::file::File;
+use crate::results::Violation;
 
 pub struct Rule {}
 
@@ -10,8 +11,8 @@ impl crate::rules::Rule for Rule {
         String::from("E0002")
     }
 
-    fn validate(&self, statement: &Statement) -> Vec<Suggestion> {
-        let mut suggestions = Vec::new();
+    fn validate(&self, file: &File, statement: &Statement) -> Vec<Violation> {
+        let mut violations = Vec::new();
 
         if let Statement::Try(s) = statement {
             for catch in &s.catches {
@@ -23,17 +24,12 @@ impl crate::rules::Rule for Rule {
                     body,
                 } = catch;
                 if body.is_empty() {
-                    suggestions.push(
-                        Suggestion::from(
-                            "There is an empty catch. It's not recommended to catch an Exception without doing anything with it..".to_string(),
-                            *start,
-                            self.get_code()
-                        )
-                    );
+                    let suggestion= String::from("There is an empty catch. It's not recommended to catch an Exception without doing anything with it..");
+                    violations.push(self.new_violation(file, suggestion, *start));
                 }
             }
         };
 
-        suggestions
+        violations
     }
 }

--- a/src/rules/e3.rs
+++ b/src/rules/e3.rs
@@ -2,7 +2,8 @@ use php_parser_rs::parser::ast::classes::ClassMember;
 use php_parser_rs::parser::ast::modifiers::MethodModifierGroup;
 use php_parser_rs::parser::ast::Statement;
 
-use crate::project::Suggestion;
+use crate::file::File;
+use crate::results::Violation;
 
 pub struct Rule {}
 
@@ -11,8 +12,8 @@ impl crate::rules::Rule for Rule {
         String::from("E0003")
     }
 
-    fn validate(&self, statement: &Statement) -> Vec<Suggestion> {
-        let mut suggestions = Vec::new();
+    fn validate(&self, file: &File, statement: &Statement) -> Vec<Violation> {
+        let mut violations = Vec::new();
 
         if let Statement::Class(class) = statement {
             for member in &class.body.members {
@@ -21,10 +22,12 @@ impl crate::rules::Rule for Rule {
                         let method_name = &concretemethod.name.value;
                         let MethodModifierGroup { modifiers } = &concretemethod.modifiers;
                         if modifiers.is_empty() {
-                            suggestions.push(Suggestion::from(
-                                format!("The method {} has no modifiers.", method_name).to_string(),
+                            let suggestion =
+                                format!("The method {} has no modifiers.", method_name);
+                            violations.push(self.new_violation(
+                                file,
+                                suggestion,
                                 concretemethod.function,
-                                self.get_code(),
                             ))
                         };
                     }
@@ -32,11 +35,12 @@ impl crate::rules::Rule for Rule {
                         let method_name = &constructor.name.value;
                         let MethodModifierGroup { modifiers } = &constructor.modifiers;
                         if modifiers.is_empty() {
-                            suggestions.push(Suggestion::from(
-                                format!("This method {} has no modifiers.", method_name)
-                                    .to_string(),
+                            let suggestion =
+                                format!("This method {} has no modifiers.", method_name);
+                            violations.push(self.new_violation(
+                                file,
+                                suggestion,
                                 constructor.function,
-                                self.get_code(),
                             ))
                         };
                     }
@@ -45,6 +49,6 @@ impl crate::rules::Rule for Rule {
             }
         };
 
-        suggestions
+        violations
     }
 }

--- a/src/rules/e4.rs
+++ b/src/rules/e4.rs
@@ -2,7 +2,8 @@ use php_parser_rs::parser::ast::classes::ClassMember;
 use php_parser_rs::parser::ast::constant::ConstantEntry;
 use php_parser_rs::parser::ast::Statement;
 
-use crate::project::Suggestion;
+use crate::file::File;
+use crate::results::Violation;
 
 pub struct Rule {}
 
@@ -11,45 +12,44 @@ impl crate::rules::Rule for Rule {
         String::from("E0004")
     }
 
-    fn validate(&self, statement: &Statement) -> Vec<Suggestion> {
-        let mut suggestions = Vec::new();
+    fn validate(&self, file: &File, statement: &Statement) -> Vec<Violation> {
+        let mut violations = Vec::new();
 
         if let Statement::Class(class) = statement {
             for member in &class.body.members {
                 if let ClassMember::Constant(constant) = member {
                     for entry in &constant.entries {
-                        if !uppercased_constant_name(entry.clone()) {
-                            suggestions.push(Suggestion::from(
-                                format!(
-                                    "All letters in a constant({}) should be uppercased.",
-                                    entry.name.value
-                                ),
-                                entry.name.span,
-                                self.get_code(),
-                            ))
+                        if !Self::uppercased_constant_name(entry.clone()) {
+                            let suggestion = format!(
+                                "All letters in a constant({}) should be uppercased.",
+                                entry.name.value
+                            );
+                            violations.push(self.new_violation(file, suggestion, entry.name.span))
                         }
                     }
                 }
             }
         };
 
-        suggestions
+        violations
     }
 }
-/// Check if the constant name is entry all uppercase.
-pub fn uppercased_constant_name(entry: ConstantEntry) -> bool {
-    let ConstantEntry {
-        name,
-        equals: _,
-        value: _,
-    } = entry;
 
-    let mut is_uppercase = true;
-    for l in name.value.to_string().chars() {
-        if !l.is_uppercase() && l.is_alphabetic() {
-            is_uppercase = l.is_uppercase()
+impl Rule {
+    fn uppercased_constant_name(entry: ConstantEntry) -> bool {
+        let ConstantEntry {
+            name,
+            equals: _,
+            value: _,
+        } = entry;
+
+        let mut is_uppercase = true;
+        for l in name.value.to_string().chars() {
+            if !l.is_uppercase() && l.is_alphabetic() {
+                is_uppercase = l.is_uppercase()
+            }
         }
-    }
 
-    is_uppercase
+        is_uppercase
+    }
 }

--- a/src/rules/e5.rs
+++ b/src/rules/e5.rs
@@ -1,7 +1,7 @@
-use php_parser_rs::lexer::token::Span;
 use php_parser_rs::parser::ast::Statement;
 
-use crate::project::Suggestion;
+use crate::file::File;
+use crate::results::Violation;
 
 pub static CODE: &str = "E0005";
 
@@ -12,29 +12,17 @@ impl crate::rules::Rule for Rule {
         String::from(CODE)
     }
 
-    fn validate(&self, statement: &Statement) -> Vec<Suggestion> {
-        let mut suggestions = Vec::new();
+    fn validate(&self, file: &File, statement: &Statement) -> Vec<Violation> {
+        let mut violations = Vec::new();
 
         if let Statement::Class(class) = statement {
             let name = String::from(class.name.value.clone());
-            if let Some(s) = has_capitalized_name(name.clone(), class.class) {
-                suggestions.push(s);
+            if !name.chars().next().unwrap().is_uppercase() {
+                let suggestion = format!("The class name {} is not capitlized. The first letter of the name of the class should be in uppercase.", name);
+                violations.push(self.new_violation(file, suggestion, class.class))
             }
         };
 
-        suggestions
-    }
-}
-pub fn has_capitalized_name(name: String, span: Span) -> Option<Suggestion> {
-    if !name.chars().next().unwrap().is_uppercase() {
-        Some(
-            Suggestion::from(
-                format!("The class name {} is not capitlized. The first letter of the name of the class should be in uppercase.", name).to_string(),
-                span,
-                String::from(CODE)
-            )
-        )
-    } else {
-        None
+        violations
     }
 }

--- a/src/rules/e6.rs
+++ b/src/rules/e6.rs
@@ -3,7 +3,8 @@ use php_parser_rs::parser::ast::modifiers::PropertyModifierGroup;
 use php_parser_rs::parser::ast::properties::{Property, PropertyEntry};
 use php_parser_rs::parser::ast::Statement;
 
-use crate::project::Suggestion;
+use crate::file::File;
+use crate::results::Violation;
 
 pub struct Rule {}
 
@@ -12,54 +13,53 @@ impl crate::rules::Rule for Rule {
         String::from("E0006")
     }
 
-    fn validate(&self, statement: &Statement) -> Vec<Suggestion> {
-        let mut suggestions = Vec::new();
+    fn validate(&self, file: &File, statement: &Statement) -> Vec<Violation> {
+        let mut violations = Vec::new();
 
         if let Statement::Class(class) = statement {
             for member in &class.body.members {
                 if let ClassMember::Property(property) = member {
-                    let name = property_name(property.clone());
-                    if property_without_modifiers(property.clone()) {
-                        suggestions.push(Suggestion::from(
-                            format!("The variables {} have no modifier.", name.join(", "))
-                                .to_string(),
-                            property.end,
-                            self.get_code(),
-                        ));
+                    if Self::property_without_modifiers(property.clone()) {
+                        let name = Self::property_name(property.clone());
+                        let suggestion =
+                            format!("The variables {} have no modifier.", name.join(", "));
+                        violations.push(self.new_violation(file, suggestion, property.end));
                     }
                 }
             }
         };
 
-        suggestions
+        violations
     }
 }
-/// Check if the porperty has a modifier.
-pub fn property_without_modifiers(property: Property) -> bool {
-    let PropertyModifierGroup { modifiers } = property.modifiers;
-    modifiers.is_empty()
-}
-fn property_name(property: Property) -> Vec<std::string::String> {
-    let Property {
-        attributes: _,
-        modifiers: _,
-        r#type: _,
-        entries,
-        end: _,
-    } = property;
-    {
-        let mut names: Vec<String> = Vec::new();
-        for entry in entries {
-            let name = match entry {
-                PropertyEntry::Initialized {
-                    variable,
-                    equals: _,
-                    value: _,
-                } => variable.name.to_string(),
-                PropertyEntry::Uninitialized { variable } => variable.to_string(),
-            };
-            names.push(name);
+
+impl Rule {
+    fn property_without_modifiers(property: Property) -> bool {
+        let PropertyModifierGroup { modifiers } = property.modifiers;
+        modifiers.is_empty()
+    }
+    fn property_name(property: Property) -> Vec<std::string::String> {
+        let Property {
+            attributes: _,
+            modifiers: _,
+            r#type: _,
+            entries,
+            end: _,
+        } = property;
+        {
+            let mut names: Vec<String> = Vec::new();
+            for entry in entries {
+                let name = match entry {
+                    PropertyEntry::Initialized {
+                        variable,
+                        equals: _,
+                        value: _,
+                    } => variable.name.to_string(),
+                    PropertyEntry::Uninitialized { variable } => variable.to_string(),
+                };
+                names.push(name);
+            }
+            names
         }
-        names
     }
 }

--- a/src/rules/e9.rs
+++ b/src/rules/e9.rs
@@ -6,7 +6,8 @@ use php_parser_rs::parser::ast::{
     BlockStatement, ExpressionStatement, Statement,
 };
 
-use crate::project::Suggestion;
+use crate::file::File;
+use crate::results::Violation;
 
 pub struct Rule {}
 
@@ -15,12 +16,11 @@ impl crate::rules::Rule for Rule {
         String::from("E0009")
     }
 
-    fn validate(
-        &self,
-        statement: &php_parser_rs::parser::ast::Statement,
-    ) -> Vec<crate::project::Suggestion> {
-        let mut suggestions = Vec::new();
+    fn validate(&self, file: &File, statement: &Statement) -> Vec<Violation> {
+        let mut violations = Vec::new();
         let mut graph = Graph { n: 0, e: 0, p: 0 };
+        let suggestion =
+            String::from("This method body is too complex. Make it easier to understand.");
 
         if let Statement::Class(class) = statement {
             for member in &class.body.members {
@@ -35,18 +35,17 @@ impl crate::rules::Rule for Rule {
                         let graph = calculate_cyclomatic_complexity(statements.clone(), &mut graph);
 
                         if graph.calculate() > 10 {
-                            suggestions.push(Suggestion::from(
-                                "This method body is too complex. Make it easier to understand."
-                                    .to_string(),
+                            violations.push(self.new_violation(
+                                file,
+                                suggestion.clone(),
                                 concretemethod.function,
-                                self.get_code(),
                             ));
                         }
                     }
                 }
             }
         }
-        suggestions
+        violations
     }
 }
 

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -1,10 +1,13 @@
-use php_parser_rs::parser::ast::Statement;
-use serde_json::Value;
 use std::collections::HashMap;
 use std::default::Default;
 
+use php_parser_rs::lexer::token::Span;
+use php_parser_rs::parser::ast::Statement;
+use serde_json::Value;
+
 use crate::config::Config;
-use crate::project::Suggestion;
+use crate::file::File;
+use crate::results::Violation;
 
 pub mod e1;
 pub mod e10;
@@ -36,7 +39,18 @@ pub trait Rule {
         }
     }
 
-    fn validate(&self, statement: &Statement) -> Vec<Suggestion>;
+    fn validate(&self, file: &File, statement: &Statement) -> Vec<Violation>;
+
+    fn new_violation(&self, file: &File, suggestion: String, span: Span) -> Violation {
+        let line = file.content.lines().nth(span.line - 1).unwrap();
+
+        Violation {
+            rule: self.get_code(),
+            line: String::from(line),
+            suggestion,
+            span,
+        }
+    }
 }
 
 fn add_rule(rules: &mut HashMap<String, Box<dyn Rule>>, rule: Box<dyn Rule>) {


### PR DESCRIPTION
- Simplify files scanning
- Removed `storage` and `output` configurations
- Introduced output formats: text (default) and json
- Added new `output_summary_only` CLI argument
- Refactoring
