### PR TITLE
feat: Added unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "phanalist"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "bindgen",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phanalist"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/analyse.rs
+++ b/src/analyse.rs
@@ -245,3 +245,75 @@ impl Analyse {
         suggestions
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn get_all_codes() -> Vec<String> {
+        vec![
+            "RULE1".to_string(),
+            "RULE2".to_string(),
+            "RULE3".to_string(),
+            "RULE4".to_string(),
+        ]
+    }
+
+    fn get_enabled_codes() -> Vec<String> {
+        vec![
+            "RULE1".to_string(),
+            "RULE3".to_string(),
+            "RULE103".to_string(),
+        ]
+    }
+
+    fn get_disabled_codes() -> Vec<String> {
+        vec![
+            "RULE2".to_string(),
+            "RULE3".to_string(),
+            "RULE203".to_string(),
+        ]
+    }
+
+    #[test]
+    fn test_filter_active_codes_all_enabled() {
+        let all_codes = get_all_codes();
+        let active_codes = Analyse::filter_active_codes(all_codes.clone(), vec![], vec![]);
+
+        assert_eq!(all_codes, active_codes);
+    }
+
+    #[test]
+    fn test_filter_active_codes_some_enabled() {
+        let all_codes = get_all_codes();
+        let enabled_codes = get_enabled_codes();
+        let active_codes =
+            Analyse::filter_active_codes(all_codes.clone(), enabled_codes.clone(), vec![]);
+
+        assert_eq!(vec!["RULE1".to_string(), "RULE3".to_string()], active_codes);
+    }
+
+    #[test]
+    fn test_filter_active_codes_some_disabled() {
+        let all_codes = get_all_codes();
+        let disabled_codes = get_disabled_codes();
+        let active_codes =
+            Analyse::filter_active_codes(all_codes.clone(), vec![], disabled_codes.clone());
+
+        assert_eq!(vec!["RULE1".to_string(), "RULE4".to_string()], active_codes);
+    }
+
+    #[test]
+    fn test_filter_active_codes_some_enabled_and_disabled() {
+        let all_codes = get_all_codes();
+        let disabled_codes = get_disabled_codes();
+        let enabled_codes = get_enabled_codes();
+        let active_codes = Analyse::filter_active_codes(
+            all_codes.clone(),
+            enabled_codes.clone(),
+            disabled_codes.clone(),
+        );
+
+        assert_eq!(vec!["RULE1".to_string()], active_codes);
+    }
+}

--- a/src/project.rs
+++ b/src/project.rs
@@ -11,7 +11,7 @@ use crate::analyse::Analyse;
 use crate::config::Config;
 use crate::file::File;
 use crate::output::{Format, Json, OutputFormatter, Text};
-use crate::results::Results;
+use crate::results::{Results, Violation};
 
 pub struct Project {}
 
@@ -76,13 +76,10 @@ impl Project {
                 ast: ast.clone(),
             };
 
-            if file.get_fully_qualified_name().is_some() {
-                for statement in file.ast.clone() {
-                    results.add_file_violations(&file, analyze.analyse(&file, statement));
-                }
+            let violations = self.analyse_file(&file, &analyze);
+            results.add_file_violations(&file, violations);
 
-                files += 1;
-            };
+            files += 1;
         }
 
         if show_bar {
@@ -104,5 +101,17 @@ impl Project {
             Format::json => Json::output(results),
             _ => Text::output(results),
         };
+    }
+
+    pub(crate) fn analyse_file(&self, file: &File, analyze: &Analyse) -> Vec<Violation> {
+        let mut violations: Vec<Violation> = vec![];
+
+        if file.get_fully_qualified_name().is_some() {
+            for statement in file.ast.clone() {
+                violations.append(&mut analyze.analyse(file, statement));
+            }
+        };
+
+        violations
     }
 }

--- a/src/results.rs
+++ b/src/results.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::file::File;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Violation {
     pub rule: String,
     pub line: String,
@@ -56,5 +56,110 @@ impl Results {
             .iter()
             .sum::<i64>()
             > 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    fn get_results() -> Results {
+        Results {
+            files: Default::default(),
+            codes_count: Default::default(),
+            total_files_count: 0,
+            duration: None,
+        }
+    }
+    fn get_file(name: &str) -> File {
+        File {
+            path: PathBuf::from(name),
+            content: "Content".to_string(),
+            ast: vec![],
+        }
+    }
+    fn get_violation(rule: &str) -> Violation {
+        Violation {
+            rule: rule.to_string(),
+            line: "Line".to_string(),
+            suggestion: "Suggestion".to_string(),
+            span: Span {
+                line: 0,
+                column: 0,
+                position: 0,
+            },
+        }
+    }
+
+    #[test]
+    fn test_add_file_violations_expected_file_violations() {
+        let mut results = get_results();
+
+        let file1 = get_file("./class1.php");
+        let file2 = get_file("./class2.php");
+
+        let violation1 = get_violation("E001");
+        let violation2 = get_violation("E002");
+        let violation3 = get_violation("E003");
+        let violation4 = get_violation("E004");
+
+        results.add_file_violations(&file1, vec![violation1.clone(), violation2.clone()]);
+        results.add_file_violations(&file2, vec![violation3.clone()]);
+        results.add_file_violations(&file1, vec![violation4.clone()]);
+
+        let expected_file1_violations = vec![violation1, violation2, violation4];
+        let expected_file2_violations = vec![violation3];
+
+        assert_eq!(
+            results.files.get("./class1.php").unwrap(),
+            &expected_file1_violations
+        );
+        assert_eq!(
+            results.files.get("./class2.php").unwrap(),
+            &expected_file2_violations
+        );
+    }
+
+    #[test]
+    fn test_add_file_violations_expected_codes_count() {
+        let mut results = get_results();
+
+        let file1 = get_file("./class1.php");
+        let file2 = get_file("./class2.php");
+
+        let violation1 = get_violation("E001");
+        let violation2 = get_violation("E002");
+        let violation3 = get_violation("E003");
+        let violation4 = get_violation("E001");
+
+        results.add_file_violations(&file1, vec![violation1, violation2]);
+        results.add_file_violations(&file2, vec![violation3]);
+        results.add_file_violations(&file1, vec![violation4]);
+
+        let mut expected_codes_count: HashMap<String, i64> = HashMap::new();
+        expected_codes_count.insert("E001".to_string(), 2);
+        expected_codes_count.insert("E002".to_string(), 1);
+        expected_codes_count.insert("E003".to_string(), 1);
+
+        assert_eq!(results.codes_count, expected_codes_count);
+    }
+
+    #[test]
+    fn test_has_any_violations_expected_true() {
+        let mut results = get_results();
+        let file1 = get_file("./class1.php");
+        let violation1 = get_violation("E001");
+
+        results.add_file_violations(&file1, vec![violation1]);
+
+        assert!(results.has_any_violations());
+    }
+
+    #[test]
+    fn test_has_any_violations_expected_false() {
+        let results = get_results();
+        assert!(!results.has_any_violations());
     }
 }

--- a/src/rules/e1.rs
+++ b/src/rules/e1.rs
@@ -3,11 +3,13 @@ use php_parser_rs::parser::ast::Statement;
 use crate::file::File;
 use crate::results::Violation;
 
+pub static CODE: &str = "E0001";
+
 pub struct Rule {}
 
 impl crate::rules::Rule for Rule {
     fn get_code(&self) -> String {
-        String::from("E0001")
+        String::from(CODE)
     }
 
     fn description(&self) -> String {
@@ -21,7 +23,7 @@ impl crate::rules::Rule for Rule {
             Statement::FullOpeningTag(tag) => {
                 let span = tag.span;
                 if span.line > 1 {
-                    let suggestion= String::from("The opening tag <?php is not on the right line. This should always be the first line in a PHP file.");
+                    let suggestion= String::from("The opening tag is not on the right line. This should always be the first line in a PHP file.");
                     violations.push(self.new_violation(file, suggestion, span));
                 }
 
@@ -36,7 +38,7 @@ impl crate::rules::Rule for Rule {
             Statement::ShortOpeningTag(tag) => {
                 let span = tag.span;
                 if span.line > 1 {
-                    let suggestion= String::from("The opening tag <?php is not on the right line. This should always be the first line in a PHP file.");
+                    let suggestion= String::from("The opening tag is not on the right line. This should always be the first line in a PHP file.");
                     violations.push(self.new_violation(file, suggestion, span));
                 }
 
@@ -53,5 +55,64 @@ impl crate::rules::Rule for Rule {
         };
 
         violations
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::rules::tests::analyze_file_for_rule;
+
+    use super::*;
+
+    #[test]
+    fn full_opening_tag_valid() {
+        let violations = analyze_file_for_rule("e1/full_opening_tag_valid.php", CODE);
+
+        assert!(violations.len().eq(&0));
+    }
+
+    #[test]
+    fn full_opening_tag_not_first_line() {
+        let violations = analyze_file_for_rule("e1/full_opening_tag_not_first_line.php", CODE);
+
+        assert!(violations.len().gt(&0));
+        assert_eq!(violations.get(0).unwrap().suggestion, "The opening tag is not on the right line. This should always be the first line in a PHP file.".to_string());
+    }
+
+    #[test]
+    fn test_full_opening_tag_not_first_column() {
+        let violations = analyze_file_for_rule("e1/full_opening_tag_not_first_column.php", CODE);
+
+        assert!(violations.len().gt(&0));
+        assert_eq!(
+            violations.get(0).unwrap().suggestion,
+            "The opening tag doesn't start at the right column: 2.".to_string()
+        );
+    }
+
+    #[test]
+    fn short_opening_tag_valid() {
+        let violations = analyze_file_for_rule("e1/short_opening_tag_valid.php", CODE);
+
+        assert!(violations.len().eq(&0));
+    }
+
+    #[test]
+    fn short_opening_tag_not_first_line() {
+        let violations = analyze_file_for_rule("e1/short_opening_tag_not_first_line.php", CODE);
+
+        assert!(violations.len().gt(&0));
+        assert_eq!(violations.get(0).unwrap().suggestion, "The opening tag is not on the right line. This should always be the first line in a PHP file.".to_string());
+    }
+
+    #[test]
+    fn short_full_opening_tag_not_first_column() {
+        let violations = analyze_file_for_rule("e1/short_opening_tag_not_first_column.php", CODE);
+
+        assert!(violations.len().gt(&0));
+        assert_eq!(
+            violations.get(0).unwrap().suggestion,
+            "The opening tag doesn't start at the right column: 2.".to_string()
+        );
     }
 }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -74,3 +74,32 @@ pub fn all_rules() -> HashMap<String, Box<dyn Rule>> {
 
     rules
 }
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+
+    use php_parser_rs::parser;
+
+    use crate::analyse::Analyse;
+    use crate::project::Project;
+
+    use super::*;
+
+    pub(crate) fn analyze_file_for_rule(path: &str, rule_code: &str) -> Vec<Violation> {
+        let path = PathBuf::from(format!("./src/rules/test/{path}"));
+        let content = fs::read_to_string(path.clone()).unwrap();
+        let ast = parser::parse(&content).unwrap();
+        let file = File { path, content, ast };
+
+        let config = Config {
+            enabled_rules: vec![rule_code.to_string()],
+            ..Default::default()
+        };
+        let analyse = Analyse::new(config);
+
+        let project = Project {};
+        project.analyse_file(&file, &analyse)
+    }
+}


### PR DESCRIPTION
We should cover all the rules with similar tests to `rules::e1::tests`:

```
% cargo test                                                                   
    Finished test [unoptimized + debuginfo] target(s) in 0.34s
     Running unittests src/main.rs (target/debug/deps/phanalist-c1fb44641648e901)

running 15 tests
test results::tests::test_has_any_violations_expected_false ... ok
test analyse::tests::test_filter_active_codes_some_disabled ... ok
test analyse::tests::test_filter_active_codes_some_enabled ... ok
test analyse::tests::test_filter_active_codes_all_enabled ... ok
test analyse::tests::test_filter_active_codes_some_enabled_and_disabled ... ok
test rules::e9::calculate ... ok
test results::tests::test_add_file_violations_expected_codes_count ... ok
test results::tests::test_has_any_violations_expected_true ... ok
test results::tests::test_add_file_violations_expected_file_violations ... ok
test rules::e1::tests::test_full_opening_tag_not_first_column ... ok
test rules::e1::tests::short_full_opening_tag_not_first_column ... ok
test rules::e1::tests::full_opening_tag_valid ... ok
test rules::e1::tests::short_opening_tag_not_first_line ... ok
test rules::e1::tests::full_opening_tag_not_first_line ... ok
test rules::e1::tests::short_opening_tag_valid ... ok

test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```