### PR TITLE
Add support for configurable verbosity levels during scanning

### DIFF
--- a/src/analyse.rs
+++ b/src/analyse.rs
@@ -22,7 +22,25 @@ use crate::results::{Results, Violation};
 use crate::rules::Rule;
 use crate::rules::{self};
 
-pub fn scan_folder(current_dir: PathBuf, sender: Sender<(String, PathBuf)>) {
+/// Print a verbose line. When a progress bar is active, route it through
+/// `ProgressBar::println` so the bar stays pinned to the bottom and the line
+/// scrolls above it; otherwise fall back to plain stderr.
+fn log_line(bar: Option<&ProgressBar>, msg: String) {
+    match bar {
+        // Only the drawn bar can pin itself to the bottom. When stderr isn't a
+        // TTY the bar is hidden and `println` is a no-op, so fall back to
+        // `eprintln!` to keep verbose output visible when piped to a file.
+        Some(pb) if !pb.is_hidden() => pb.println(msg),
+        _ => eprintln!("{msg}"),
+    }
+}
+
+pub fn scan_folder(
+    current_dir: PathBuf,
+    sender: Sender<(String, PathBuf)>,
+    verbose: u8,
+    bar: Option<ProgressBar>,
+) {
     for entry in WalkDir::new(current_dir).follow_links(false) {
         let entry = entry.unwrap();
         let path = entry.path();
@@ -37,6 +55,9 @@ pub fn scan_folder(current_dir: PathBuf, sender: Sender<(String, PathBuf)>) {
         if (file_name != "." || !file_name.is_empty()) && metadata.is_file() {
             if let Some(extension) = path.extension() {
                 if extension == "php" {
+                    if verbose >= 2 {
+                        log_line(bar.as_ref(), format!("[vv] reading {}", path.display()));
+                    }
                     let content = fs::read_to_string(entry.path());
                     match content {
                         Err(_) => {
@@ -69,6 +90,7 @@ impl Analyse {
         _config: &Config,
         show_bar: bool,
         format: &Format,
+        verbose: u8,
     ) -> Results {
         let now = std::time::Instant::now();
         let mut results = Results::default();
@@ -81,10 +103,17 @@ impl Analyse {
             println!("Scanning files in {} ...", &path.to_string().bold());
         }
 
+        let bar_active = show_bar && format == &Format::text;
+        let thread_bar = if bar_active {
+            Some(progress_bar.clone())
+        } else {
+            None
+        };
+
         let scan_path = path.clone();
         std::thread::spawn(move || {
             let path = PathBuf::from(scan_path);
-            self::scan_folder(path, send);
+            self::scan_folder(path, send, verbose, thread_bar);
         });
 
         let arena = Bump::new();
@@ -92,11 +121,23 @@ impl Analyse {
         // 1. Collect all files
         let mut scanned_files: Vec<File<'_>> = Vec::new();
         for (content, path) in recv {
+            if verbose >= 2 {
+                log_line(
+                    bar_active.then_some(&progress_bar),
+                    format!("[vv] parsing {}", path.display()),
+                );
+            }
             scanned_files.push(File::new(&arena, path, content));
         }
 
         // 2. Pre-pass (indexing).
         for file in &scanned_files {
+            if verbose >= 3 {
+                log_line(
+                    bar_active.then_some(&progress_bar),
+                    format!("[vvv] indexing {}", file.path.display()),
+                );
+            }
             for rule in self.rules.values() {
                 rule.index_file(file);
             }
@@ -105,7 +146,13 @@ impl Analyse {
         // 3. Main pass.
         let mut files = 0;
         for mut file in scanned_files {
-            if show_bar && format == &Format::text {
+            if verbose >= 1 {
+                log_line(
+                    bar_active.then_some(&progress_bar),
+                    format!("[v] analysing {}", file.path.display()),
+                );
+            }
+            if bar_active {
                 progress_bar.inc(1);
             }
 
@@ -115,7 +162,7 @@ impl Analyse {
             files += 1;
         }
 
-        if show_bar && format == &Format::text {
+        if bar_active {
             progress_bar.finish();
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub fn scan(path: String) -> results::Results {
 
     let analyze: Analyse = Analyse::new(&config);
 
-    analyze.scan("./src".to_string(), &config, false, &output_format)
+    analyze.scan("./src".to_string(), &config, false, &output_format,0)
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,10 @@ struct Args {
     #[arg(short, long)]
     /// Do not output the results
     quiet: bool,
+    #[arg(short, long, action = clap::ArgAction::Count)]
+    /// Increase verbosity. Repeat to print each file as it is scanned:
+    /// -v main pass, -vv parsing, -vvv indexing
+    verbose: u8,
 }
 
 fn main() {
@@ -75,6 +79,7 @@ fn main() {
             &config,
             format != Format::json && !quiet,
             &format,
+            args.verbose,
         );
         if !quiet {
             analyze.output(&mut results, format.clone(), args.summary_only);


### PR DESCRIPTION
I have an issue with one of the files but I could not figure out which one :) So I added verbose output.

Example output:

```shell
Using configuration file ./phanalist.yaml

Scanning files in ./src/ ...
[vv] reading file.php
[vv] parsing file.php
[vvv] indexing file.php
[v] analysing file.php
```