### PR TITLE
Introduce debug statistics for rule timings and cost metrics

### DIFF
--- a/src/analyse.rs
+++ b/src/analyse.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::sync::mpsc::Sender;
+use std::time::Instant;
 
 use bumpalo::Bump;
 use colored::Colorize;
@@ -11,6 +12,7 @@ use jwalk::WalkDir;
 use mago_syntax::ast::Statement;
 
 use crate::config::Config;
+use crate::debug_stats::{FileTimings, RuleTimings};
 use crate::file::File;
 use crate::outputs::codeclimate::CodeClimate;
 use crate::outputs::json::Json;
@@ -69,9 +71,13 @@ impl Analyse {
         _config: &Config,
         show_bar: bool,
         format: &Format,
+        collect_rule_metrics: bool,
     ) -> Results {
         let now = std::time::Instant::now();
         let mut results = Results::default();
+        if collect_rule_metrics {
+            results.rule_timings = Some(RuleTimings::default());
+        }
         let progress_bar = self.get_progress_bar(&path);
 
         let (send, recv) = std::sync::mpsc::channel();
@@ -109,8 +115,13 @@ impl Analyse {
                 progress_bar.inc(1);
             }
 
-            let violations = self.analyse_file(&mut file);
+            let (violations, file_timings) = self.analyse_file(&mut file, collect_rule_metrics);
+            let file_path = file.path.display().to_string();
             results.add_file_violations(&file, violations);
+
+            if let (Some(rt), Some(ft)) = (results.rule_timings.as_mut(), file_timings) {
+                rt.merge_file(file_path, ft);
+            }
 
             files += 1;
         }
@@ -195,16 +206,29 @@ impl Analyse {
         };
     }
 
-    pub(crate) fn analyse_file(&self, file: &mut File<'_>) -> Vec<Violation> {
+    pub(crate) fn analyse_file(
+        &self,
+        file: &mut File<'_>,
+        collect_rule_metrics: bool,
+    ) -> (Vec<Violation>, Option<FileTimings>) {
         let mut violations: Vec<Violation> = vec![];
+        let mut timings = if collect_rule_metrics {
+            Some(FileTimings::new())
+        } else {
+            None
+        };
 
         if let Some(program) = file.ast {
             file.reference_counter.build_reference_counter(program);
             for statement in program.statements.iter() {
-                violations.append(&mut self.analyse_file_statement(file, statement));
+                violations.append(&mut self.analyse_file_statement(
+                    file,
+                    statement,
+                    timings.as_mut(),
+                ));
             }
         }
-        violations
+        (violations, timings)
     }
 
     fn get_active_rules(config: &Config) -> HashMap<String, Box<dyn Rule>> {
@@ -255,14 +279,29 @@ impl Analyse {
         &self,
         file: &File<'a>,
         statement: &Statement<'a>,
+        mut timings: Option<&mut FileTimings>,
     ) -> Vec<Violation> {
         let mut violations = Vec::new();
 
         for rule in self.rules.values() {
-            if rule.do_validate(file) {
-                for statement in rule.flatten_statements_to_validate(statement) {
+            let rule_start = timings.as_ref().map(|_| Instant::now());
+
+            let validated = rule.do_validate(file);
+            let mut stmt_count = 0;
+            if validated {
+                let flat = rule.flatten_statements_to_validate(statement);
+                stmt_count = flat.len();
+                for statement in flat {
                     violations.append(&mut rule.validate(file, statement));
                 }
+            }
+
+            if let Some(t) = timings.as_deref_mut() {
+                let elapsed = rule_start.unwrap().elapsed();
+                let entry = t.entry(rule.get_code()).or_default();
+                entry.duration += elapsed;
+                entry.validated |= validated;
+                entry.statements += stmt_count;
             }
         }
 

--- a/src/debug_stats.rs
+++ b/src/debug_stats.rs
@@ -1,0 +1,349 @@
+use std::collections::HashMap;
+use std::time::Duration;
+
+use cli_table::{format::Justify, Cell, Style, Table};
+
+/// One rule's metrics on a single file.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct FileRuleMetric {
+    /// Summed flatten + validate time on this file (including the do_validate check).
+    pub duration: Duration,
+    /// Whether do_validate() engaged on this file.
+    pub validated: bool,
+    /// Number of statement nodes the rule actually inspected.
+    pub statements: usize,
+}
+
+/// Per-file accumulation, owned and returned by `analyse_file`.
+/// Keyed by rule code.
+pub type FileTimings = HashMap<String, FileRuleMetric>;
+
+/// Collected across a scan: one (file_path, metric) sample per file per rule.
+#[derive(Debug, Default, Clone)]
+pub struct RuleTimings {
+    pub per_file: HashMap<String, Vec<(String, FileRuleMetric)>>,
+}
+
+/// Computed, display-ready view for one rule.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RuleStat {
+    pub code: String,
+    pub samples: usize,
+    // per-file timing
+    pub min: Duration,
+    pub max: Duration,
+    pub avg: Duration,
+    pub p90: Duration,
+    pub p95: Duration,
+    pub p99: Duration,
+    // cost / coverage
+    pub total: Duration,
+    pub pct_of_total: f64,
+    pub files_validated: usize,
+    pub files_skipped: usize,
+    pub statements: usize,
+    pub violations: i64,
+    pub slowest: Vec<(String, Duration)>,
+}
+
+impl RuleTimings {
+    /// Append one sample per rule from a finished file.
+    pub fn merge_file(&mut self, file_path: String, timings: FileTimings) {
+        for (code, metric) in timings {
+            self.per_file
+                .entry(code)
+                .or_default()
+                .push((file_path.clone(), metric));
+        }
+    }
+
+    /// Render the debug section to stdout. `show_timing` prints the per-file
+    /// timing table + slowest-files listing; `show_stats` prints the cost table.
+    pub fn print_text(
+        &self,
+        codes_count: &HashMap<String, i64>,
+        total_files: i64,
+        show_timing: bool,
+        show_stats: bool,
+    ) {
+        let stats = self.compute(codes_count);
+        if stats.is_empty() {
+            return;
+        }
+
+        println!();
+        println!("Rule debug ({total_files} files):");
+
+        if show_timing {
+            let mut by_p99 = stats.clone();
+            by_p99.sort_by_key(|s| std::cmp::Reverse(s.p99));
+
+            let rows: Vec<Vec<_>> = by_p99
+                .iter()
+                .map(|s| {
+                    vec![
+                        s.code.as_str().cell(),
+                        s.samples.cell().justify(Justify::Right),
+                        format!("{:.2?}", s.min).cell().justify(Justify::Right),
+                        format!("{:.2?}", s.avg).cell().justify(Justify::Right),
+                        format!("{:.2?}", s.p90).cell().justify(Justify::Right),
+                        format!("{:.2?}", s.p95).cell().justify(Justify::Right),
+                        format!("{:.2?}", s.p99).cell().justify(Justify::Right),
+                        format!("{:.2?}", s.max).cell().justify(Justify::Right),
+                    ]
+                })
+                .collect();
+
+            let table = rows
+                .table()
+                .title(vec![
+                    "Rule".cell().bold(true),
+                    "Files".cell().bold(true),
+                    "Min".cell().bold(true),
+                    "Avg".cell().bold(true),
+                    "p90".cell().bold(true),
+                    "p95".cell().bold(true),
+                    "p99".cell().bold(true),
+                    "Max".cell().bold(true),
+                ])
+                .bold(true);
+            println!("{}", table.display().unwrap());
+
+            let mut by_total = stats.clone();
+            by_total.sort_by_key(|s| std::cmp::Reverse(s.total));
+            println!("Slowest files per rule:");
+            for s in &by_total {
+                println!("  {}:", s.code);
+                for (path, dur) in &s.slowest {
+                    println!("    {:>10}  {}", format!("{dur:.2?}"), path);
+                }
+            }
+        }
+
+        if show_stats {
+            let mut by_total = stats.clone();
+            by_total.sort_by_key(|s| std::cmp::Reverse(s.total));
+
+            let rows: Vec<Vec<_>> = by_total
+                .iter()
+                .map(|s| {
+                    vec![
+                        s.code.as_str().cell(),
+                        format!("{:.2?}", s.total).cell().justify(Justify::Right),
+                        format!("{:.1}%", s.pct_of_total).cell().justify(Justify::Right),
+                        s.violations.cell().justify(Justify::Right),
+                        format!("{}/{}", s.files_validated, s.files_skipped)
+                            .cell()
+                            .justify(Justify::Right),
+                        s.statements.cell().justify(Justify::Right),
+                    ]
+                })
+                .collect();
+
+            let table = rows
+                .table()
+                .title(vec![
+                    "Rule".cell().bold(true),
+                    "Total".cell().bold(true),
+                    "% Total".cell().bold(true),
+                    "Violations".cell().bold(true),
+                    "Valid/Skip".cell().bold(true),
+                    "Statements".cell().bold(true),
+                ])
+                .bold(true);
+            println!("{}", table.display().unwrap());
+        }
+    }
+
+    /// Aggregate into per-rule stats. `codes_count` supplies violation counts.
+    pub fn compute(&self, codes_count: &HashMap<String, i64>) -> Vec<RuleStat> {
+        let grand_total_nanos: u128 = self
+            .per_file
+            .values()
+            .flat_map(|v| v.iter())
+            .map(|(_, m)| m.duration.as_nanos())
+            .sum::<u128>()
+            .max(1);
+
+        let mut stats = Vec::new();
+        for (code, samples) in &self.per_file {
+            let n = samples.len();
+            if n == 0 {
+                continue;
+            }
+
+            let mut durations: Vec<Duration> = samples.iter().map(|(_, m)| m.duration).collect();
+            durations.sort();
+
+            let total: Duration = durations.iter().sum();
+            let avg = total / n as u32;
+            let min = durations[0];
+            let max = durations[n - 1];
+
+            // Nearest-rank percentile: rank = ceil(p/100 * n), clamped to [1, n].
+            let percentile = |pct: f64| -> Duration {
+                let rank = ((pct / 100.0) * n as f64).ceil() as usize;
+                let idx = rank.clamp(1, n) - 1;
+                durations[idx]
+            };
+
+            let files_validated = samples.iter().filter(|(_, m)| m.validated).count();
+            let statements = samples.iter().map(|(_, m)| m.statements).sum();
+
+            let mut slowest: Vec<(String, Duration)> = samples
+                .iter()
+                .map(|(path, m)| (path.clone(), m.duration))
+                .collect();
+            slowest.sort_by_key(|&(_, d)| std::cmp::Reverse(d));
+            slowest.truncate(5);
+
+            let pct_of_total = total.as_nanos() as f64 / grand_total_nanos as f64 * 100.0;
+
+            stats.push(RuleStat {
+                code: code.clone(),
+                samples: n,
+                min,
+                max,
+                avg,
+                p90: percentile(90.0),
+                p95: percentile(95.0),
+                p99: percentile(99.0),
+                total,
+                pct_of_total,
+                files_validated,
+                files_skipped: n - files_validated,
+                statements,
+                violations: codes_count.get(code).copied().unwrap_or(0),
+                slowest,
+            });
+        }
+        stats
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn metric(ms: u64, validated: bool, statements: usize) -> FileRuleMetric {
+        FileRuleMetric {
+            duration: Duration::from_millis(ms),
+            validated,
+            statements,
+        }
+    }
+
+    fn timings_with(samples: Vec<(&str, FileRuleMetric)>) -> RuleTimings {
+        let mut t = RuleTimings::default();
+        let per: Vec<(String, FileRuleMetric)> =
+            samples.into_iter().map(|(p, m)| (p.to_string(), m)).collect();
+        t.per_file.insert("E0001".to_string(), per);
+        t
+    }
+
+    fn only_stat(stats: Vec<RuleStat>) -> RuleStat {
+        assert_eq!(stats.len(), 1);
+        stats.into_iter().next().unwrap()
+    }
+
+    #[test]
+    fn percentiles_on_1_to_100ms() {
+        let mut t = RuleTimings::default();
+        let per: Vec<(String, FileRuleMetric)> = (1..=100u64)
+            .map(|ms| (format!("f{ms}.php"), metric(ms, true, 0)))
+            .collect();
+        t.per_file.insert("E0001".to_string(), per);
+
+        let stat = only_stat(t.compute(&HashMap::new()));
+        assert_eq!(stat.samples, 100);
+        assert_eq!(stat.min, Duration::from_millis(1));
+        assert_eq!(stat.max, Duration::from_millis(100));
+        assert_eq!(stat.avg, Duration::from_micros(50_500)); // 5050ms / 100
+        assert_eq!(stat.p90, Duration::from_millis(90));
+        assert_eq!(stat.p95, Duration::from_millis(95));
+        assert_eq!(stat.p99, Duration::from_millis(99));
+        assert_eq!(stat.total, Duration::from_millis(5050));
+    }
+
+    #[test]
+    fn percentiles_single_sample() {
+        let t = timings_with(vec![("a.php", metric(7, true, 3))]);
+        let stat = only_stat(t.compute(&HashMap::new()));
+        assert_eq!(stat.samples, 1);
+        assert_eq!(stat.min, Duration::from_millis(7));
+        assert_eq!(stat.max, Duration::from_millis(7));
+        assert_eq!(stat.avg, Duration::from_millis(7));
+        assert_eq!(stat.p90, Duration::from_millis(7));
+        assert_eq!(stat.p95, Duration::from_millis(7));
+        assert_eq!(stat.p99, Duration::from_millis(7));
+    }
+
+    #[test]
+    fn percentiles_three_samples() {
+        let t = timings_with(vec![
+            ("a.php", metric(10, true, 1)),
+            ("b.php", metric(20, true, 1)),
+            ("c.php", metric(30, true, 1)),
+        ]);
+        let stat = only_stat(t.compute(&HashMap::new()));
+        assert_eq!(stat.min, Duration::from_millis(10));
+        assert_eq!(stat.max, Duration::from_millis(30));
+        assert_eq!(stat.avg, Duration::from_millis(20));
+        assert_eq!(stat.p90, Duration::from_millis(30));
+        assert_eq!(stat.p95, Duration::from_millis(30));
+        assert_eq!(stat.p99, Duration::from_millis(30));
+    }
+
+    #[test]
+    fn coverage_and_violations() {
+        let t = timings_with(vec![
+            ("a.php", metric(10, true, 4)),
+            ("b.php", metric(0, false, 0)),
+            ("c.php", metric(5, true, 2)),
+        ]);
+        let mut codes = HashMap::new();
+        codes.insert("E0001".to_string(), 9);
+
+        let stat = only_stat(t.compute(&codes));
+        assert_eq!(stat.files_validated, 2);
+        assert_eq!(stat.files_skipped, 1);
+        assert_eq!(stat.statements, 6);
+        assert_eq!(stat.violations, 9);
+        assert_eq!(stat.total, Duration::from_millis(15));
+    }
+
+    #[test]
+    fn pct_of_total_sums_to_100() {
+        let mut t = RuleTimings::default();
+        t.per_file.insert(
+            "E0001".to_string(),
+            vec![("a.php".to_string(), metric(30, true, 0))],
+        );
+        t.per_file.insert(
+            "E0002".to_string(),
+            vec![("a.php".to_string(), metric(10, true, 0))],
+        );
+        let stats = t.compute(&HashMap::new());
+        let sum: f64 = stats.iter().map(|s| s.pct_of_total).sum();
+        assert!((sum - 100.0).abs() < 0.001, "pct sum was {sum}");
+        let e1 = stats.iter().find(|s| s.code == "E0001").unwrap();
+        assert!((e1.pct_of_total - 75.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn slowest_truncates_to_5_descending() {
+        let t = timings_with(vec![
+            ("a.php", metric(1, true, 0)),
+            ("b.php", metric(6, true, 0)),
+            ("c.php", metric(3, true, 0)),
+            ("d.php", metric(5, true, 0)),
+            ("e.php", metric(2, true, 0)),
+            ("f.php", metric(4, true, 0)),
+        ]);
+        let stat = only_stat(t.compute(&HashMap::new()));
+        assert_eq!(stat.slowest.len(), 5);
+        let durations: Vec<u64> = stat.slowest.iter().map(|(_, d)| d.as_millis() as u64).collect();
+        assert_eq!(durations, vec![6, 5, 4, 3, 2]);
+        assert_eq!(stat.slowest[0].0, "b.php");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ use analyse::Analyse;
 use outputs::Format;
 pub mod analyse;
 pub mod config;
+pub mod debug_stats;
 pub mod file;
 pub mod outputs;
 pub mod results;
@@ -13,7 +14,7 @@ pub fn scan(path: String) -> results::Results {
 
     let analyze: Analyse = Analyse::new(&config);
 
-    analyze.scan("./src".to_string(), &config, false, &output_format)
+    analyze.scan("./src".to_string(), &config, false, &output_format, false)
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use crate::outputs::Format;
 
 mod analyse;
 mod config;
+mod debug_stats;
 mod file;
 mod outputs;
 mod results;
@@ -37,6 +38,12 @@ struct Args {
     #[arg(short, long)]
     /// Do not output the results
     quiet: bool,
+    #[arg(long)]
+    /// Print per-rule per-file timing (min/max/avg/p90/p95/p99 + slowest files)
+    debug_rule_timing: bool,
+    #[arg(long)]
+    /// Print per-rule cost/coverage stats (total time, %, violations, files, statements)
+    debug_rule_stats: bool,
 }
 
 fn main() {
@@ -69,16 +76,35 @@ fn main() {
 
     let mut has_violations = false;
 
+    let collect_rule_metrics = args.debug_rule_timing || args.debug_rule_stats;
+
+    if collect_rule_metrics && format != Format::text {
+        eprintln!("--debug-rule-timing/--debug-rule-stats only produce output with text format");
+    }
+
     for path in paths.iter() {
         let mut results = analyze.scan(
             path.clone(),
             &config,
             format != Format::json && !quiet,
             &format,
+            collect_rule_metrics,
         );
         if !quiet {
             analyze.output(&mut results, format.clone(), args.summary_only);
         }
+
+        if collect_rule_metrics && format == Format::text {
+            if let Some(rt) = &results.rule_timings {
+                rt.print_text(
+                    &results.codes_count,
+                    results.total_files_count,
+                    args.debug_rule_timing,
+                    args.debug_rule_stats,
+                );
+            }
+        }
+
         has_violations = has_violations || results.has_any_violations();
     }
 

--- a/src/results.rs
+++ b/src/results.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
+use crate::debug_stats::RuleTimings;
 use crate::file::File;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -22,6 +23,8 @@ pub struct Results {
     pub codes_count: HashMap<String, i64>,
     pub total_files_count: i64,
     pub duration: Option<Duration>,
+    #[serde(skip)]
+    pub rule_timings: Option<RuleTimings>,
 }
 
 impl Results {
@@ -75,6 +78,7 @@ mod tests {
             codes_count: Default::default(),
             total_files_count: 0,
             duration: None,
+            rule_timings: None,
         }
     }
     fn get_file<'a>(arena: &'a Bump, name: &str) -> File<'a> {

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -377,7 +377,7 @@ mod tests {
             rule.index_file(&file);
         }
 
-        analyse.analyse_file(&mut file)
+        analyse.analyse_file(&mut file, false).0
     }
 
     fn get_ns() -> String {


### PR DESCRIPTION
Adds two CLI flags, `--debug-rule-timing` and `--debug-rule-stats`, for profiling how each enabled rule performs across the scanned PHP files. 

`--debug-rule-timing prints` a per-file timing table (min, avg, p90, p95, p99, max, sorted by p99) plus the five slowest files per rule, while `--debug-rule-stats` prints a cost table (total time, percent of total, violations found, files validated/skipped, statements inspected). Both flags feed one shared collector, so either one turns on collection and setting both prints timing first, then stats. Timing is captured per (rule, file) as owned per-file data merged after each file, which keeps the hot path lock-free, and the collection path is fully skipped (zero overhead) when neither flag is set. 

Output is text-only, `json/sarif/codeclimate` runs accept the flags but emit a single stderr note instead, and the new Results.rule_timings field is skipped so machine-format schemas are unchanged. 

New logic lives in `src/debug_stats.rs` (data model, percentile math, printer) with unit tests, wired through `src/analyse.rs` and `src/main.rs`.

Example output:
```shell
Analysed 102 files in 85.68ms, memory usage: 12.4 MiB

Rule debug (102 files):
+-------+-------+----------+----------+----------+----------+----------+----------+
| Rule  | Files | Min      | Avg      | p90      | p95      | p99      | Max      |
+-------+-------+----------+----------+----------+----------+----------+----------+
| E0014 |   102 | 418.08µs | 528.84µs | 695.43µs | 789.55µs | 986.36µs |   1.13ms |
+-------+-------+----------+----------+----------+----------+----------+----------+
| E0022 |   102 | 450.00ns |  49.43µs |  77.18µs |  88.61µs | 109.16µs | 114.22µs |
+-------+-------+----------+----------+----------+----------+----------+----------+
| E0023 |   102 | 370.00ns |  49.86µs |  76.72µs |  91.28µs | 100.13µs | 132.67µs |
+-------+-------+----------+----------+----------+----------+----------+----------+
| E0017 |   102 | 381.00ns |   5.08µs |   8.12µs |  10.46µs |  52.01µs | 101.35µs |
+-------+-------+----------+----------+----------+----------+----------+----------+
| E0018 |   102 | 340.00ns |   2.02µs |   1.83µs |   2.15µs |  47.20µs |  54.41µs |
+-------+-------+----------+----------+----------+----------+----------+----------+
| E0010 |   102 | 370.00ns |   1.78µs |   1.87µs |   2.24µs |  39.78µs |  39.99µs |
+-------+-------+----------+----------+----------+----------+----------+----------+
| E0019 |   102 | 420.00ns |   2.47µs |   3.25µs |   6.56µs |  32.20µs |  38.12µs |
+-------+-------+----------+----------+----------+----------+----------+----------+
| E0015 |   102 | 101.00ns |   7.49µs |  14.63µs |  16.82µs |  23.78µs |  54.83µs |
+-------+-------+----------+----------+----------+----------+----------+----------+
| E0011 |   102 | 561.00ns |   3.29µs |   3.06µs |   8.74µs |  17.51µs | 137.43µs |
+-------+-------+----------+----------+----------+----------+----------+----------+
| E0021 |   102 | 471.00ns |   2.20µs |   2.78µs |   3.28µs |  13.24µs |  27.95µs |
+-------+-------+----------+----------+----------+----------+----------+----------+
| E0013 |   102 | 340.00ns |   2.73µs |   4.57µs |   7.98µs |  13.08µs |  48.86µs |
+-------+-------+----------+----------+----------+----------+----------+----------+
| E0020 |   102 | 420.00ns |   2.01µs |   2.42µs |   2.76µs |  11.95µs |  26.00µs |
+-------+-------+----------+----------+----------+----------+----------+----------+
| E0002 |   102 | 411.00ns |   2.20µs |   3.38µs |   4.68µs |  10.49µs |  70.39µs |
+-------+-------+----------+----------+----------+----------+----------+----------+
| E0007 |   102 | 391.00ns |   1.34µs |   1.66µs |   1.95µs |   8.22µs |  25.53µs |
+-------+-------+----------+----------+----------+----------+----------+----------+
| E0006 |   102 | 401.00ns |   1.34µs |   1.64µs |   2.13µs |   7.78µs |  25.21µs |
+-------+-------+----------+----------+----------+----------+----------+----------+
| E0012 |   102 | 210.00ns |   1.53µs |   2.88µs |   4.98µs |   6.66µs |   7.22µs |
+-------+-------+----------+----------+----------+----------+----------+----------+
| E0016 |   102 | 340.00ns |   1.57µs |   2.10µs |   2.78µs |   6.48µs |  42.25µs |
+-------+-------+----------+----------+----------+----------+----------+----------+
| E0000 |   102 | 140.00ns |   2.09µs |   3.16µs |   3.53µs |   5.59µs |  26.50µs |
+-------+-------+----------+----------+----------+----------+----------+----------+
| E0009 |   102 | 390.00ns |   1.28µs |   1.39µs |   1.77µs |   5.57µs |  37.11µs |
+-------+-------+----------+----------+----------+----------+----------+----------+
| E0008 |   102 | 381.00ns |   1.36µs |   1.84µs |   3.30µs |   5.26µs |  25.79µs |
+-------+-------+----------+----------+----------+----------+----------+----------+
| E0005 |   102 | 461.00ns |   1.29µs |   1.63µs |   1.95µs |   3.88µs |  24.99µs |
+-------+-------+----------+----------+----------+----------+----------+----------+
| E0001 |   102 | 511.00ns |   1.44µs |   2.15µs |   2.74µs |   3.87µs |   4.18µs |
+-------+-------+----------+----------+----------+----------+----------+----------+
| E0003 |   102 | 400.00ns |   1.22µs |   1.50µs |   1.94µs |   3.86µs |  25.65µs |
+-------+-------+----------+----------+----------+----------+----------+----------+
| E0004 |   102 | 311.00ns |   1.17µs |   1.46µs |   1.63µs |   3.84µs |  25.59µs |
+-------+-------+----------+----------+----------+----------+----------+----------+

Slowest files per rule:
  E0014:
        1.13ms  src/rules/examples/e14/invalid_cross_class.php
      986.36µs  src/rules/examples/e14/invalid_property_chain.php
      922.43µs  src/rules/examples/e14/valid_property_typed.php
      901.74µs  src/rules/examples/e17/self_and_duplicates.php
      818.56µs  src/rules/examples/e12/set_in_method.php
  E0023:
      132.67µs  src/rules/examples/e12/increment_local_in_static_method.php
      100.13µs  src/rules/examples/e10/npath.php
       98.70µs  src/rules/examples/e12/set_in_method_finalliy.php
       94.48µs  src/rules/examples/e12/set_in_method.php
       94.00µs  src/rules/examples/e12/set_array_in_method.php
  E0022:
      114.22µs  src/rules/examples/e12/increment_local_in_static_method.php
      109.16µs  src/rules/examples/e12/set_in_method_finalliy.php
       95.93µs  src/rules/examples/e10/npath.php
       94.44µs  src/rules/examples/e12/set_in_method.php
       92.57µs  src/rules/examples/e12/set_array_in_method.php
  E0015:
       54.83µs  src/rules/examples/e10/npath.php
       23.78µs  src/rules/examples/e19/high_rfc.php
       22.36µs  src/rules/examples/e12/test.php
       21.56µs  src/rules/examples/e12/set_in_return_nested_method.php
       18.38µs  src/rules/examples/e13/private_method_not_being_called.php
  E0017:
      101.35µs  src/rules/examples/e10/npath.php
       52.01µs  src/rules/examples/e19/high_rfc.php
       23.53µs  src/rules/examples/e17/high_coupling.php
       17.05µs  src/rules/examples/e21/many_children.php
       13.78µs  src/rules/examples/e18/high_wmc.php
  E0011:
      137.43µs  src/rules/examples/e10/npath.php
       17.51µs  src/rules/examples/e18/high_wmc.php
       11.59µs  src/rules/examples/e9/complex.php
        9.81µs  src/rules/examples/e19/high_rfc.php
        8.86µs  src/rules/examples/e11/detect_@.php
  E0013:
       48.86µs  src/rules/examples/e10/npath.php
       13.08µs  src/rules/examples/e19/high_rfc.php
       12.82µs  src/rules/examples/e13/private_method_not_being_called.php
        8.41µs  src/rules/examples/e18/high_wmc.php
        8.38µs  src/rules/examples/e19/repeated_calls.php
  E0019:
       38.12µs  src/rules/examples/e10/npath.php
       32.20µs  src/rules/examples/e19/high_rfc.php
       25.65µs  src/rules/examples/e19/low_rfc.php
        7.26µs  src/rules/examples/e17/function_calls_not_types.php
        7.13µs  src/rules/examples/e12/read_array_null_coalescing_or_null.php
  E0002:
       70.39µs  src/rules/examples/e10/npath.php
       10.49µs  src/rules/examples/e18/high_wmc.php
        5.11µs  src/rules/examples/e13/private_method_not_being_called.php
        5.05µs  src/rules/examples/e9/complex.php
        4.76µs  src/rules/examples/e2/empty_catch.php
  E0021:
       27.95µs  src/rules/examples/e10/npath.php
       13.24µs  src/rules/examples/e12/set_array_in_method.php
        7.72µs  src/rules/examples/e21/many_children.php
        4.23µs  src/rules/examples/e18/high_wmc.php
        4.03µs  src/rules/examples/e20/deep_inheritance.php
  E0000:
       26.50µs  src/rules/examples/e10/npath.php
        5.59µs  src/rules/examples/e12/read_static_array_null_coalescing_or_array.php
        4.48µs  src/rules/examples/e13/private_method_not_being_called.php
        4.22µs  src/rules/examples/e18/high_wmc.php
        4.18µs  src/rules/examples/e12/increment_in_method.php
  E0018:
       54.41µs  src/rules/examples/e4/uppercase_constant.php
       47.20µs  src/rules/examples/e10/npath.php
        7.60µs  src/rules/examples/e18/high_wmc.php
        2.78µs  src/rules/examples/e19/high_rfc.php
        2.50µs  src/rules/examples/e9/complex.php
  E0020:
       26.00µs  src/rules/examples/e10/npath.php
       11.95µs  src/rules/examples/e21/many_children.php
       11.52µs  src/rules/examples/e20/deep_inheritance.php
        4.36µs  src/rules/examples/e18/high_wmc.php
        3.91µs  src/rules/examples/e14/invalid_cross_class.php
  E0010:
       39.99µs  src/rules/examples/e10/npath.php
       39.78µs  src/rules/examples/e2/non_empty_catch.php
        5.78µs  src/rules/examples/e18/high_wmc.php
        2.66µs  src/rules/examples/e19/high_rfc.php
        2.51µs  src/rules/examples/e9/complex.php
  E0016:
       42.25µs  src/rules/examples/e10/npath.php
        6.48µs  src/rules/examples/e18/high_wmc.php
        4.43µs  src/rules/examples/e9/complex.php
        4.10µs  src/rules/examples/e19/high_rfc.php
        3.65µs  src/rules/examples/e16/complex.php
  E0012:
        7.22µs  src/rules/examples/e12/set_in_method.php
        6.66µs  src/rules/examples/e12/set_in_method_try.php
        6.01µs  src/rules/examples/e12/set_in_method_catch.php
        5.98µs  src/rules/examples/e12/increment_in_method.php
        5.47µs  src/rules/examples/e12/set_in_null_coalescing.php
  E0001:
        4.18µs  src/rules/examples/e13/private_method_not_being_called.php
        3.87µs  src/rules/examples/e1/short_opening_tag_not_first_column.php
        3.64µs  src/rules/examples/e12/read_static_null_coalescing_or_throw.php
        3.59µs  src/rules/examples/e1/full_opening_tag_not_first_column.php
        3.36µs  src/rules/examples/e4/no_uppercase_constant.php
  E0008:
       25.79µs  src/rules/examples/e10/npath.php
        5.26µs  src/rules/examples/e15/closure_cohesion.php
        4.41µs  src/rules/examples/e18/high_wmc.php
        3.65µs  src/rules/examples/e15/cohesive.php
        3.49µs  src/rules/examples/e15/anonymous_class.php
  E0006:
       25.21µs  src/rules/examples/e10/npath.php
        7.78µs  src/rules/examples/e6/no_var_modifiers.php
        5.39µs  src/rules/examples/e17/self_and_duplicates.php
        3.79µs  src/rules/examples/e18/high_wmc.php
        2.29µs  src/rules/examples/e19/high_rfc.php
  E0007:
       25.53µs  src/rules/examples/e10/npath.php
        8.22µs  src/rules/examples/e12/read_array_null_coalescing_or_array.php
        4.73µs  src/rules/examples/e7/method_max_params.php
        3.74µs  src/rules/examples/e18/high_wmc.php
        2.32µs  src/rules/examples/e19/high_rfc.php
  E0005:
       24.99µs  src/rules/examples/e10/npath.php
        3.88µs  src/rules/examples/e18/high_wmc.php
        2.72µs  src/rules/examples/e2/empty_catch.php
        2.48µs  src/rules/examples/e5/non_capitalized_classname.php
        2.19µs  src/rules/examples/e19/high_rfc.php
  E0009:
       37.11µs  src/rules/examples/e10/npath.php
        5.57µs  src/rules/examples/e18/high_wmc.php
        3.20µs  src/rules/examples/e9/complex.php
        2.68µs  src/rules/examples/e19/high_rfc.php
        1.81µs  src/rules/examples/e16/complex.php
  E0003:
       25.65µs  src/rules/examples/e10/npath.php
        3.86µs  src/rules/examples/e18/high_wmc.php
        3.85µs  src/rules/examples/e3/no_constructor_modifiers.php
        2.40µs  src/rules/examples/e19/high_rfc.php
        2.10µs  src/rules/examples/e3/no_method_modifiers.php
  E0004:
       25.59µs  src/rules/examples/e10/npath.php
        3.84µs  src/rules/examples/e18/high_wmc.php
        2.48µs  src/rules/examples/e19/high_rfc.php
        2.44µs  src/rules/examples/e4/no_uppercase_constant.php
        1.80µs  src/rules/examples/e9/complex.php
+-------+----------+---------+------------+------------+------------+
| Rule  | Total    | % Total | Violations | Valid/Skip | Statements |
+-------+----------+---------+------------+------------+------------+
| E0014 |  53.94ms |   78.3% |          5 |      102/0 |        222 |
+-------+----------+---------+------------+------------+------------+
| E0023 |   5.09ms |    7.4% |         34 |      102/0 |       1293 |
+-------+----------+---------+------------+------------+------------+
| E0022 |   5.04ms |    7.3% |          0 |      102/0 |       1293 |
+-------+----------+---------+------------+------------+------------+
| E0015 | 763.93µs |    1.1% |         10 |      100/2 |       1288 |
+-------+----------+---------+------------+------------+------------+
| E0017 | 518.20µs |    0.8% |          2 |      102/0 |       1293 |
+-------+----------+---------+------------+------------+------------+
| E0011 | 335.67µs |    0.5% |          6 |      102/0 |       1293 |
+-------+----------+---------+------------+------------+------------+
| E0013 | 278.06µs |    0.4% |          9 |      102/0 |       1293 |
+-------+----------+---------+------------+------------+------------+
| E0019 | 252.35µs |    0.4% |          1 |      102/0 |       1293 |
+-------+----------+---------+------------+------------+------------+
| E0002 | 224.50µs |    0.3% |          1 |      102/0 |       1293 |
+-------+----------+---------+------------+------------+------------+
| E0021 | 224.19µs |    0.3% |          1 |      102/0 |       1293 |
+-------+----------+---------+------------+------------+------------+
| E0000 | 213.59µs |    0.3% |          0 |      100/2 |       1288 |
+-------+----------+---------+------------+------------+------------+
| E0018 | 206.64µs |    0.3% |          2 |      102/0 |       1293 |
+-------+----------+---------+------------+------------+------------+
| E0020 | 205.50µs |    0.3% |          1 |      102/0 |       1293 |
+-------+----------+---------+------------+------------+------------+
| E0010 | 181.73µs |    0.3% |          1 |      102/0 |       1293 |
+-------+----------+---------+------------+------------+------------+
| E0016 | 159.98µs |    0.2% |          3 |      102/0 |       1293 |
+-------+----------+---------+------------+------------+------------+
| E0012 | 155.77µs |    0.2% |         10 |      52/50 |        274 |
+-------+----------+---------+------------+------------+------------+
| E0001 | 147.48µs |    0.2% |          4 |      102/0 |        102 |
+-------+----------+---------+------------+------------+------------+
| E0008 | 138.24µs |    0.2% |         10 |      102/0 |       1293 |
+-------+----------+---------+------------+------------+------------+
| E0006 | 136.62µs |    0.2% |          3 |      102/0 |       1293 |
+-------+----------+---------+------------+------------+------------+
| E0007 | 136.28µs |    0.2% |          1 |      102/0 |       1293 |
+-------+----------+---------+------------+------------+------------+
| E0005 | 131.91µs |    0.2% |          1 |      102/0 |       1293 |
+-------+----------+---------+------------+------------+------------+
| E0009 | 131.02µs |    0.2% |          2 |      102/0 |       1293 |
+-------+----------+---------+------------+------------+------------+
| E0003 | 124.30µs |    0.2% |          2 |      102/0 |       1293 |
+-------+----------+---------+------------+------------+------------+
| E0004 | 119.10µs |    0.2% |          1 |      102/0 |       1293 |
+-------+----------+---------+------------+------------+------------+
```