### PR TITLE
refactor: structured violation messages with stable ids

### DIFF
--- a/docs/adding_new_rule.md
+++ b/docs/adding_new_rule.md
@@ -18,7 +18,18 @@
     ```bash
     cp -r src/rules/examples/e0 src/rules/examples/e1234
     ```
-5. Implement `validate` function in `src/rules/e1234.rs`. And cover it with tests in `mod tests`.
+5. Implement the `validate` function in `src/rules/e1234.rs`, returning a `Violation` for each problem found. Build the message with `Message::new(id, template)`. The `id` is a stable slug (used as a key, e.g. by the baseline), so keep it fixed even if you reword the text. Put dynamic values in `{placeholder}` args rather than formatting them into the id or template text:
+    ```rust
+    use crate::results::{Message, Violation};
+
+    let message = Message::new(
+        "E1234:short-slug",
+        "Explain the problem with {name}.",
+    )
+    .arg("name", name.to_string());
+    violations.push(self.new_violation(file, message, span));
+    ```
+    Cover it with tests in `mod tests`, asserting on `violation.message.render()`.
 6. Enable the new rule in `src/rules/mod.rs`:
     ```rust
     ...

--- a/src/outputs/codeclimate.rs
+++ b/src/outputs/codeclimate.rs
@@ -25,7 +25,7 @@ impl OutputFormatter for CodeClimate {
                 res.push(json!({
                     "type": "issue",
                     "check_name": &violation.rule,
-                    "description": &violation.suggestion,
+                    "description": violation.message.render(),
                     "content": {
                         "body": &rule_markdown
                     },

--- a/src/outputs/sarif.rs
+++ b/src/outputs/sarif.rs
@@ -97,7 +97,7 @@ impl OutputFormatter for Sarif {
                 };
 
                 let message = Message {
-                    text: Some(String::from(&violation.suggestion)),
+                    text: Some(violation.message.render()),
                     ..Default::default()
                 };
 

--- a/src/outputs/text.rs
+++ b/src/outputs/text.rs
@@ -44,7 +44,7 @@ impl Text {
                     println!(
                         "  {}:\t{}",
                         suggestion.rule.yellow().bold(),
-                        suggestion.suggestion.bold()
+                        suggestion.message.render().bold()
                     );
                     println!(
                         "  {}\t{} {}",

--- a/src/results.rs
+++ b/src/results.rs
@@ -1,20 +1,78 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use serde::{Deserialize, Serialize};
+use serde::ser::SerializeStruct;
+use serde::{Deserialize, Serialize, Serializer};
 
 use crate::debug_stats::RuleTimings;
 use crate::file::File;
 
+/// A diagnostic message. `id` is a stable slug used as a key (e.g. by the
+/// baseline); `template` is human text with `{name}` placeholders that `args`
+/// fill in. `render()` produces the displayed string. Marked `#[non_exhaustive]`
+/// so future fields (severity, help url, fix data) are additive.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[non_exhaustive]
+pub struct Message {
+    pub id: String,
+    pub template: String,
+    pub args: Vec<(String, String)>,
+}
+
+impl Message {
+    pub fn new(id: impl Into<String>, template: impl Into<String>) -> Self {
+        Message {
+            id: id.into(),
+            template: template.into(),
+            args: Vec::new(),
+        }
+    }
+
+    pub fn arg(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.args.push((name.into(), value.into()));
+        self
+    }
+
+    /// Substitute `args` into the `{name}` placeholders of the template.
+    pub fn render(&self) -> String {
+        let mut out = self.template.clone();
+        for (name, value) in &self.args {
+            out = out.replace(&format!("{{{name}}}"), value);
+        }
+        out
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct Violation {
     pub rule: String,
     pub line: String,
-    pub suggestion: String,
+    pub message: Message,
     pub start_line: usize,
     pub start_column: usize,
     pub end_line: usize,
     pub end_column: usize,
+}
+
+// Custom serialization: emit the structured `message` and also a flat, rendered
+// `suggestion` string so consumers of the JSON output that read the old
+// `suggestion` field keep working.
+impl Serialize for Violation {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("Violation", 8)?;
+        state.serialize_field("rule", &self.rule)?;
+        state.serialize_field("line", &self.line)?;
+        state.serialize_field("suggestion", &self.message.render())?;
+        state.serialize_field("message", &self.message)?;
+        state.serialize_field("start_line", &self.start_line)?;
+        state.serialize_field("start_column", &self.start_column)?;
+        state.serialize_field("end_line", &self.end_line)?;
+        state.serialize_field("end_column", &self.end_column)?;
+        state.end()
+    }
 }
 
 #[derive(Serialize, Debug, Deserialize, Clone, Default)]
@@ -82,12 +140,48 @@ mod tests {
         Violation {
             rule: rule.to_string(),
             line: "Line".to_string(),
-            suggestion: "Suggestion".to_string(),
+            message: Message::new("test", "Suggestion"),
             start_line: 0,
             start_column: 0,
             end_line: 0,
             end_column: 0,
         }
+    }
+
+    #[test]
+    fn message_render_without_args_returns_template() {
+        let m = Message::new("e1.x", "A plain message.");
+        assert_eq!(m.render(), "A plain message.");
+    }
+
+    #[test]
+    fn message_render_substitutes_named_args() {
+        let m = Message::new("e1.col", "Wrong column: {column}.").arg("column", "2");
+        assert_eq!(m.render(), "Wrong column: 2.");
+    }
+
+    #[test]
+    fn message_render_substitutes_multiple_args() {
+        let m = Message::new("e", "{a} then {b}")
+            .arg("a", "first")
+            .arg("b", "second");
+        assert_eq!(m.render(), "first then second");
+    }
+
+    #[test]
+    fn message_keeps_id() {
+        assert_eq!(Message::new("e1.x", "t").id, "e1.x");
+    }
+
+    #[test]
+    fn violation_json_has_rendered_suggestion_and_structured_message() {
+        let v = get_violation("E001");
+        let json = serde_json::to_string(&v).unwrap();
+        // Backward-compatible flat rendered string...
+        assert!(json.contains("\"suggestion\":\"Suggestion\""));
+        // ...plus the structured message with its stable id.
+        assert!(json.contains("\"message\":{"));
+        assert!(json.contains("\"id\":\"test\""));
     }
 
     #[test]

--- a/src/rules/e1.rs
+++ b/src/rules/e1.rs
@@ -1,7 +1,7 @@
 use mago_syntax::ast::{OpeningTag, Statement};
 
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 
 pub(crate) static CODE: &str = "E0001";
 static DESCRIPTION: &str = "Opening tag position";
@@ -40,18 +40,20 @@ impl crate::rules::Rule for Rule {
             let column = file.column_number(span.start.offset);
 
             if line > 1 {
-                let suggestion = String::from(
+                let message = Message::new(
+                    "E0001:opening-tag-line",
                     "The opening tag is not on the right line. This should always be the first line in a PHP file.",
                 );
-                violations.push(self.new_violation(file, suggestion, span));
+                violations.push(self.new_violation(file, message, span));
             }
 
             if column > 0 {
-                let suggestion = format!(
-                    "The opening tag doesn't start at the right column: {}.",
-                    column + 1
-                );
-                violations.push(self.new_violation(file, suggestion, span));
+                let message = Message::new(
+                    "E0001:opening-tag-column",
+                    "The opening tag doesn't start at the right column: {column}.",
+                )
+                .arg("column", (column + 1).to_string());
+                violations.push(self.new_violation(file, message, span));
             }
         }
 
@@ -87,7 +89,7 @@ mod tests {
         let violations = analyze_file_for_rule("e1/full_opening_tag_not_first_line.php", CODE);
 
         assert!(violations.len().gt(&0));
-        assert_eq!(violations.first().unwrap().suggestion, "The opening tag is not on the right line. This should always be the first line in a PHP file.".to_string());
+        assert_eq!(violations.first().unwrap().message.render(), "The opening tag is not on the right line. This should always be the first line in a PHP file.".to_string());
     }
 
     #[test]
@@ -96,7 +98,7 @@ mod tests {
 
         assert!(violations.len().gt(&0));
         assert_eq!(
-            violations.first().unwrap().suggestion,
+            violations.first().unwrap().message.render(),
             "The opening tag doesn't start at the right column: 2.".to_string()
         );
     }
@@ -113,7 +115,7 @@ mod tests {
         let violations = analyze_file_for_rule("e1/short_opening_tag_not_first_line.php", CODE);
 
         assert!(violations.len().gt(&0));
-        assert_eq!(violations.first().unwrap().suggestion, "The opening tag is not on the right line. This should always be the first line in a PHP file.".to_string());
+        assert_eq!(violations.first().unwrap().message.render(), "The opening tag is not on the right line. This should always be the first line in a PHP file.".to_string());
     }
 
     #[test]
@@ -122,7 +124,7 @@ mod tests {
 
         assert!(violations.len().gt(&0));
         assert_eq!(
-            violations.first().unwrap().suggestion,
+            violations.first().unwrap().message.render(),
             "The opening tag doesn't start at the right column: 2.".to_string()
         );
     }

--- a/src/rules/e10.rs
+++ b/src/rules/e10.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 
 pub(crate) static CODE: &str = "E0010";
 static DESCRIPTION: &str = "Npath complexity";
@@ -57,11 +57,13 @@ impl crate::rules::Rule for Rule {
                     if let MethodBody::Concrete(block) = &method.body {
                         let npath = calculate_npath(&block.statements);
                         if npath > self.settings.max_paths {
-                            let suggestion = format!(
-                                "The body of {} method has {} paths. Reduce the amount of paths.",
-                                String::from_utf8_lossy(method.name.value), npath,
-                            );
-                            violations.push(self.new_violation(file, suggestion, method.span()));
+                            let message = Message::new(
+                                "E0010:too-many-paths",
+                                "The body of {name} method has {npath} paths. Reduce the amount of paths.",
+                            )
+                            .arg("name", String::from_utf8_lossy(method.name.value).to_string())
+                            .arg("npath", npath.to_string());
+                            violations.push(self.new_violation(file, message, method.span()));
                         }
                     }
                 }
@@ -196,7 +198,7 @@ mod tests {
         let violations = analyze_file_for_rule("e10/npath.php", CODE);
         assert!(violations.len().eq(&1));
         assert_eq!(
-            violations.first().unwrap().suggestion,
+            violations.first().unwrap().message.render(),
             "The body of tooManyPaths method has 319 paths. Reduce the amount of paths."
                 .to_string()
         );

--- a/src/rules/e11.rs
+++ b/src/rules/e11.rs
@@ -2,7 +2,7 @@ use mago_span::HasSpan;
 use mago_syntax::ast::{Call, Expression, Statement, UnaryPrefixOperator};
 
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 
 pub(crate) static CODE: &str = "E0011";
 static DESCRIPTION: &str = "Detect the error suppression symbol: @";
@@ -51,8 +51,11 @@ fn check_expression(
     match expr {
         Expression::UnaryPrefix(prefix) => {
             if let UnaryPrefixOperator::ErrorControl(_) = prefix.operator {
-                let suggestion = "Error supression(@) symbol found. Remove it.".to_string();
-                violations.push(rule.new_violation(file, suggestion, prefix.span()));
+                let message = Message::new(
+                    "E0011:error-suppression",
+                    "Error supression(@) symbol found. Remove it.",
+                );
+                violations.push(rule.new_violation(file, message, prefix.span()));
             }
             check_expression(file, rule, prefix.operand, violations);
         }

--- a/src/rules/e12.rs
+++ b/src/rules/e12.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 use crate::rules::Rule as RuleTrait;
 
 pub(crate) static CODE: &str = "E0012";
@@ -298,14 +298,20 @@ impl Rule {
                 Access::Property(prop) if is_this(prop.object) => {
                     violations.push(self.new_violation(
                         file,
-                        "Properties in service must be immutable. Violating Shared Memory Model.".to_string(),
+                        Message::new(
+                            "E0012:mutable-property",
+                            "Properties in service must be immutable. Violating Shared Memory Model.",
+                        ),
                         span,
                     ));
                 }
                 Access::StaticProperty(prop) if is_self_or_static_or_class(prop.class) => {
                     violations.push(self.new_violation(
                         file,
-                        "Static properties in service must be immutable. Violating Shared Memory Model.".to_string(),
+                        Message::new(
+                            "E0012:mutable-static-property",
+                            "Static properties in service must be immutable. Violating Shared Memory Model.",
+                        ),
                         span,
                     ));
                 }

--- a/src/rules/e13.rs
+++ b/src/rules/e13.rs
@@ -4,7 +4,7 @@ use mago_span::{HasSpan, Span};
 use mago_syntax::ast::*;
 
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 
 pub(crate) static CODE: &str = "E0013";
 static DESCRIPTION: &str = "Private method not being called.";
@@ -70,7 +70,11 @@ impl crate::rules::Rule for Rule {
             // Report private methods that are never called
             for (name, span) in &private_methods {
                 if !called_methods.contains(name) {
-                    let message = format!("The private method {} is not being called. ", name);
+                    let message = Message::new(
+                        "E0013:private-method-not-called",
+                        "The private method {name} is not being called. ",
+                    )
+                    .arg("name", name.to_string());
                     violations.push(self.new_violation(file, message, *span));
                 }
             }

--- a/src/rules/e14.rs
+++ b/src/rules/e14.rs
@@ -4,7 +4,7 @@ use mago_span::{HasSpan, Span};
 use mago_syntax::ast::*;
 
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 use crate::rules::Rule as RuleTrait;
 
 pub(crate) static CODE: &str = "E0014";
@@ -1104,19 +1104,22 @@ impl Rule {
             ),
             Some(t) => {
                 // Foreign type — chaining is a violation
-                let message = format!(
-                    "Law of Demeter violation. Method '{}' is called on '{}', which is a foreign object.",
-                    method_name, t
-                );
+                let message = Message::new(
+                    "E0014:foreign-object-chain",
+                    "Law of Demeter violation. Method '{method}' is called on '{type}', which is a foreign object.",
+                )
+                .arg("method", method_name.to_string())
+                .arg("type", t.to_string());
                 violations.push(self.new_violation(file, message, span));
                 None
             }
             None => {
                 // Unknown type — conservative: violation
-                let message = format!(
-                    "Law of Demeter violation. Method '{}' is called on an object of unknown type (possible foreign object).",
-                    method_name
-                );
+                let message = Message::new(
+                    "E0014:unknown-object-chain",
+                    "Law of Demeter violation. Method '{method}' is called on an object of unknown type (possible foreign object).",
+                )
+                .arg("method", method_name.to_string());
                 violations.push(self.new_violation(file, message, span));
                 None
             }

--- a/src/rules/e15.rs
+++ b/src/rules/e15.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 use crate::rules::Rule as RuleTrait;
 
 pub(crate) static CODE: &str = "E0015";
@@ -215,11 +215,14 @@ impl RuleTrait for Rule {
 
             let lcom4 = dsu.count;
             if lcom4 > self.settings.threshold {
-                let suggestion = format!(
-                    "Class \"{}\" has low cohesion (LCOM4 = {}). Consider splitting it into {} smaller classes.",
-                    String::from_utf8_lossy(class.name.value), lcom4, lcom4
-                );
-                violations.push(self.new_violation(file, suggestion, class.span()));
+                let message = Message::new(
+                    "E0015:low-cohesion",
+                    "Class \"{class}\" has low cohesion (LCOM4 = {lcom4}). Consider splitting it into {count} smaller classes.",
+                )
+                .arg("class", String::from_utf8_lossy(class.name.value).to_string())
+                .arg("lcom4", lcom4.to_string())
+                .arg("count", lcom4.to_string());
+                violations.push(self.new_violation(file, message, class.span()));
             }
         }
 
@@ -453,7 +456,7 @@ mod tests {
     fn test_non_cohesive_class() {
         let violations = analyze_file_for_rule("e15/non_cohesive.php", CODE);
         assert!(violations.len() > 0);
-        assert!(violations[0].suggestion.contains("LCOM4 = 2"));
+        assert!(violations[0].message.render().contains("LCOM4 = 2"));
     }
 
     #[test]

--- a/src/rules/e16.rs
+++ b/src/rules/e16.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 
 pub(crate) static CODE: &str = "E0016";
 static DESCRIPTION: &str = "Cognitive complexity";
@@ -55,12 +55,13 @@ impl crate::rules::Rule for Rule {
                         let complexity = calculate_cognitive_complexity(&block.statements, 0);
 
                         if complexity > self.settings.max_complexity {
-                            let suggestion = format!(
-                                "The body of {} method has {} cognitive complexity. Make it easier to understand.",
-                                String::from_utf8_lossy(method.name.value),
-                                complexity,
-                            );
-                            violations.push(self.new_violation(file, suggestion, method.span()));
+                            let message = Message::new(
+                                "E0016:high-cognitive-complexity",
+                                "The body of {method} method has {complexity} cognitive complexity. Make it easier to understand.",
+                            )
+                            .arg("method", String::from_utf8_lossy(method.name.value).to_string())
+                            .arg("complexity", complexity.to_string());
+                            violations.push(self.new_violation(file, message, method.span()));
                         }
                     }
                 }
@@ -289,7 +290,8 @@ mod tests {
         assert!(violations
             .first()
             .unwrap()
-            .suggestion
+            .message
+            .render()
             .contains("cognitive complexity"));
     }
 

--- a/src/rules/e17.rs
+++ b/src/rules/e17.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 use crate::rules::Rule as RuleTrait;
 
 pub(crate) static CODE: &str = "E0017";
@@ -75,13 +75,14 @@ impl RuleTrait for Rule {
             if coupling > self.settings.max_coupling {
                 let mut names = coupled_types.into_iter().collect::<Vec<_>>();
                 names.sort();
-                let suggestion = format!(
-                    "Class \"{}\" is coupled to {} external types ({}). Reduce the number of collaborators or split responsibilities.",
-                    current_class,
-                    coupling,
-                    names.join(", ")
-                );
-                violations.push(self.new_violation(file, suggestion, class.span()));
+                let message = Message::new(
+                    "E0017:high-coupling",
+                    "Class \"{class}\" is coupled to {coupling} external types ({types}). Reduce the number of collaborators or split responsibilities.",
+                )
+                .arg("class", current_class)
+                .arg("coupling", coupling.to_string())
+                .arg("types", names.join(", "));
+                violations.push(self.new_violation(file, message, class.span()));
             }
         }
 
@@ -737,9 +738,10 @@ mod tests {
 
         assert_eq!(violations.len(), 1);
         assert!(violations[0]
-            .suggestion
+            .message
+            .render()
             .contains("is coupled to 13 external types"));
-        assert!(violations[0].suggestion.contains("PaymentGateway"));
+        assert!(violations[0].message.render().contains("PaymentGateway"));
     }
 
     #[test]

--- a/src/rules/e18.rs
+++ b/src/rules/e18.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 use crate::rules::e9::calculate_complexity;
 use crate::rules::Rule as RuleTrait;
 
@@ -64,11 +64,14 @@ impl RuleTrait for Rule {
             }
 
             if wmc > self.settings.max_wmc {
-                let suggestion = format!(
-                    "Class \"{}\" has a Weighted Methods per Class (WMC) of {} (threshold: {}). Consider splitting responsibilities.",
-                    String::from_utf8_lossy(class.name.value), wmc, self.settings.max_wmc
-                );
-                violations.push(self.new_violation(file, suggestion, class.span()));
+                let message = Message::new(
+                    "E0018:high-wmc",
+                    "Class \"{class}\" has a Weighted Methods per Class (WMC) of {wmc} (threshold: {threshold}). Consider splitting responsibilities.",
+                )
+                .arg("class", String::from_utf8_lossy(class.name.value).into_owned())
+                .arg("wmc", wmc.to_string())
+                .arg("threshold", self.settings.max_wmc.to_string());
+                violations.push(self.new_violation(file, message, class.span()));
             }
         }
 
@@ -86,7 +89,7 @@ mod tests {
     fn high_wmc() {
         let violations = analyze_file_for_rule("e18/high_wmc.php", CODE);
         assert_eq!(violations.len(), 1);
-        assert!(violations[0].suggestion.contains("Weighted Methods per Class (WMC)"));
+        assert!(violations[0].message.render().contains("Weighted Methods per Class (WMC)"));
     }
 
     #[test]

--- a/src/rules/e19.rs
+++ b/src/rules/e19.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 use crate::rules::Rule as RuleTrait;
 
 pub(crate) static CODE: &str = "E0019";
@@ -70,11 +70,14 @@ impl RuleTrait for Rule {
             let rfc = own_method_count + called_methods.len();
 
             if rfc > self.settings.max_rfc {
-                let suggestion = format!(
-                    "Class \"{}\" has a Response For Class (RFC) of {} (threshold: {}). The class responds to too many messages.",
-                    String::from_utf8_lossy(class.name.value), rfc, self.settings.max_rfc
-                );
-                violations.push(self.new_violation(file, suggestion, class.span()));
+                let message = Message::new(
+                    "E0019:high-rfc",
+                    "Class \"{class}\" has a Response For Class (RFC) of {rfc} (threshold: {threshold}). The class responds to too many messages.",
+                )
+                .arg("class", String::from_utf8_lossy(class.name.value).into_owned())
+                .arg("rfc", rfc.to_string())
+                .arg("threshold", self.settings.max_rfc.to_string());
+                violations.push(self.new_violation(file, message, class.span()));
             }
         }
 
@@ -337,7 +340,7 @@ mod tests {
     fn high_rfc() {
         let violations = analyze_file_for_rule("e19/high_rfc.php", CODE);
         assert_eq!(violations.len(), 1);
-        assert!(violations[0].suggestion.contains("Response For Class (RFC)"));
+        assert!(violations[0].message.render().contains("Response For Class (RFC)"));
     }
 
     #[test]

--- a/src/rules/e2.rs
+++ b/src/rules/e2.rs
@@ -2,7 +2,7 @@ use mago_span::HasSpan;
 use mago_syntax::ast::Statement;
 
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 
 pub(crate) static CODE: &str = "E0002";
 static DESCRIPTION: &str = "Empty catch";
@@ -29,7 +29,8 @@ impl crate::rules::Rule for Rule {
         if let Statement::Try(s) = statement {
             for catch in s.catch_clauses.iter() {
                 if catch.block.statements.is_empty() {
-                    violations.push(self.new_violation(file, SUGGESTION.to_string(), catch.span()));
+                    let message = Message::new("E0002:empty-catch", SUGGESTION);
+                    violations.push(self.new_violation(file, message, catch.span()));
                 }
             }
         };
@@ -50,7 +51,7 @@ mod tests {
 
         assert!(violations.len().gt(&0));
         assert_eq!(
-            violations.first().unwrap().suggestion,
+            violations.first().unwrap().message.render(),
             SUGGESTION.to_string()
         );
     }

--- a/src/rules/e20.rs
+++ b/src/rules/e20.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 use crate::rules::Rule as RuleTrait;
 
 pub(crate) static CODE: &str = "E0020";
@@ -80,11 +80,14 @@ impl RuleTrait for Rule {
             let depth = self.compute_depth(&class_name);
 
             if depth > self.settings.max_depth {
-                let suggestion = format!(
-                    "Class \"{}\" has an inheritance depth of {} (threshold: {}). Deep hierarchies increase complexity.",
-                    class_name, depth, self.settings.max_depth
-                );
-                violations.push(self.new_violation(file, suggestion, class.span()));
+                let message = Message::new(
+                    "E0020:deep-inheritance",
+                    "Class \"{class}\" has an inheritance depth of {depth} (threshold: {threshold}). Deep hierarchies increase complexity.",
+                )
+                .arg("class", class_name.clone())
+                .arg("depth", depth.to_string())
+                .arg("threshold", self.settings.max_depth.to_string());
+                violations.push(self.new_violation(file, message, class.span()));
             }
         }
 
@@ -159,7 +162,7 @@ mod tests {
         assert!(violations.len() >= 1);
         assert!(violations
             .iter()
-            .any(|v| v.suggestion.contains("inheritance depth")));
+            .any(|v| v.message.render().contains("inheritance depth")));
     }
 
     #[test]

--- a/src/rules/e21.rs
+++ b/src/rules/e21.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 use crate::rules::Rule as RuleTrait;
 
 pub(crate) static CODE: &str = "E0021";
@@ -80,11 +80,14 @@ impl RuleTrait for Rule {
             let child_count = self.get_child_count(&class_name);
 
             if child_count > self.settings.max_children {
-                let suggestion = format!(
-                    "Class \"{}\" has {} direct subclasses (threshold: {}). High NOC increases the impact of changes.",
-                    class_name, child_count, self.settings.max_children
-                );
-                violations.push(self.new_violation(file, suggestion, class.span()));
+                let message = Message::new(
+                    "E0021:many-children",
+                    "Class \"{class}\" has {children} direct subclasses (threshold: {threshold}). High NOC increases the impact of changes.",
+                )
+                .arg("class", class_name.clone())
+                .arg("children", child_count.to_string())
+                .arg("threshold", self.settings.max_children.to_string());
+                violations.push(self.new_violation(file, message, class.span()));
             }
         }
 
@@ -146,7 +149,7 @@ mod tests {
     fn many_children() {
         let violations = analyze_file_for_rule("e21/many_children.php", CODE);
         assert_eq!(violations.len(), 1);
-        assert!(violations[0].suggestion.contains("direct subclasses"));
+        assert!(violations[0].message.render().contains("direct subclasses"));
     }
 
     #[test]

--- a/src/rules/e22.rs
+++ b/src/rules/e22.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 use crate::rules::Rule as RuleTrait;
 
 pub(crate) static CODE: &str = "E0022";
@@ -99,19 +99,25 @@ impl RuleTrait for Rule {
             let (ca, ce) = self.compute_coupling(&namespace);
 
             if ca > self.settings.max_ca {
-                let suggestion = format!(
-                    "Namespace \"{}\" has afferent coupling (Ca) of {} (threshold: {}). Many external classes depend on this namespace.",
-                    namespace, ca, self.settings.max_ca
-                );
-                violations.push(self.new_violation(file, suggestion, ns.span()));
+                let message = Message::new(
+                    "E0022:high-afferent-coupling",
+                    "Namespace \"{namespace}\" has afferent coupling (Ca) of {ca} (threshold: {threshold}). Many external classes depend on this namespace.",
+                )
+                .arg("namespace", namespace.clone())
+                .arg("ca", ca.to_string())
+                .arg("threshold", self.settings.max_ca.to_string());
+                violations.push(self.new_violation(file, message, ns.span()));
             }
 
             if ce > self.settings.max_ce {
-                let suggestion = format!(
-                    "Namespace \"{}\" has efferent coupling (Ce) of {} (threshold: {}). This namespace depends on too many external classes.",
-                    namespace, ce, self.settings.max_ce
-                );
-                violations.push(self.new_violation(file, suggestion, ns.span()));
+                let message = Message::new(
+                    "E0022:high-efferent-coupling",
+                    "Namespace \"{namespace}\" has efferent coupling (Ce) of {ce} (threshold: {threshold}). This namespace depends on too many external classes.",
+                )
+                .arg("namespace", namespace.clone())
+                .arg("ce", ce.to_string())
+                .arg("threshold", self.settings.max_ce.to_string());
+                violations.push(self.new_violation(file, message, ns.span()));
             }
         }
 

--- a/src/rules/e23.rs
+++ b/src/rules/e23.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 use crate::rules::Rule as RuleTrait;
 
 pub(crate) static CODE: &str = "E0023";
@@ -111,32 +111,41 @@ impl RuleTrait for Rule {
             if total_coupling > 0 {
                 let instability = ce as f64 / total_coupling as f64;
                 if instability > self.settings.max_instability {
-                    let suggestion = format!(
-                        "Namespace \"{}\" has instability (I) of {:.2} (threshold: {:.2}). Highly unstable namespaces depend on many others but few depend on them.",
-                        namespace, instability, self.settings.max_instability
-                    );
-                    violations.push(self.new_violation(file, suggestion, ns.span()));
+                    let message = Message::new(
+                        "E0023:instability",
+                        "Namespace \"{namespace}\" has instability (I) of {instability} (threshold: {threshold}). Highly unstable namespaces depend on many others but few depend on them.",
+                    )
+                    .arg("namespace", namespace.to_string())
+                    .arg("instability", format!("{:.2}", instability))
+                    .arg("threshold", format!("{:.2}", self.settings.max_instability));
+                    violations.push(self.new_violation(file, message, ns.span()));
                 }
 
                 // Abstractness: A = abstract / total
                 if total_count > 0 {
                     let abstractness = abstract_count as f64 / total_count as f64;
                     if abstractness > self.settings.max_abstractness {
-                        let suggestion = format!(
-                            "Namespace \"{}\" has abstractness (A) of {:.2} (threshold: {:.2}). Too many abstract classes without concrete implementations.",
-                            namespace, abstractness, self.settings.max_abstractness
-                        );
-                        violations.push(self.new_violation(file, suggestion, ns.span()));
+                        let message = Message::new(
+                            "E0023:abstractness",
+                            "Namespace \"{namespace}\" has abstractness (A) of {abstractness} (threshold: {threshold}). Too many abstract classes without concrete implementations.",
+                        )
+                        .arg("namespace", namespace.to_string())
+                        .arg("abstractness", format!("{:.2}", abstractness))
+                        .arg("threshold", format!("{:.2}", self.settings.max_abstractness));
+                        violations.push(self.new_violation(file, message, ns.span()));
                     }
 
                     // Distance from Main Sequence: D = |A + I - 1|
                     let distance = (abstractness + instability - 1.0).abs();
                     if distance > self.settings.max_distance {
-                        let suggestion = format!(
-                            "Namespace \"{}\" has distance from main sequence (D) of {:.2} (threshold: {:.2}). Consider rebalancing abstractness and stability.",
-                            namespace, distance, self.settings.max_distance
-                        );
-                        violations.push(self.new_violation(file, suggestion, ns.span()));
+                        let message = Message::new(
+                            "E0023:distance",
+                            "Namespace \"{namespace}\" has distance from main sequence (D) of {distance} (threshold: {threshold}). Consider rebalancing abstractness and stability.",
+                        )
+                        .arg("namespace", namespace.to_string())
+                        .arg("distance", format!("{:.2}", distance))
+                        .arg("threshold", format!("{:.2}", self.settings.max_distance));
+                        violations.push(self.new_violation(file, message, ns.span()));
                     }
                 }
             }

--- a/src/rules/e24.rs
+++ b/src/rules/e24.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 use crate::rules::Rule as RuleTrait;
 
 pub(crate) static CODE: &str = "E0024";
@@ -44,11 +44,14 @@ impl Rule {
                     }
                     let loc = end_line - start_line - 1;
                     if loc > self.settings.max_loc {
-                        let suggestion = format!(
-                            "Method \"{}\" has {} lines of code (max: {}). Consider breaking it into smaller methods.",
-                            String::from_utf8_lossy(method.name.value), loc, self.settings.max_loc
-                        );
-                        violations.push(self.new_violation(file, suggestion, method.span()));
+                        let message = Message::new(
+                            "E0024:method-too-long",
+                            "Method \"{name}\" has {loc} lines of code (max: {max}). Consider breaking it into smaller methods.",
+                        )
+                        .arg("name", String::from_utf8_lossy(method.name.value).to_string())
+                        .arg("loc", loc.to_string())
+                        .arg("max", self.settings.max_loc.to_string());
+                        violations.push(self.new_violation(file, message, method.span()));
                     }
                 }
             }
@@ -106,7 +109,7 @@ mod tests {
     fn long_method() {
         let violations = analyze_file_for_rule("e24/long_method.php", CODE);
         assert!(violations.len().gt(&0));
-        assert!(violations[0].suggestion.contains("longMethod"));
+        assert!(violations[0].message.render().contains("longMethod"));
     }
 
     #[test]

--- a/src/rules/e25.rs
+++ b/src/rules/e25.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 
 pub(crate) static CODE: &str = "E0025";
 static DESCRIPTION: &str = "Lines of Code (LOC) per File";
@@ -59,11 +59,14 @@ impl crate::rules::Rule for Rule {
         if let Some((name, span)) = name {
             let loc = file.lines.len();
             if loc > self.settings.max_loc {
-                let suggestion = format!(
-                    "File containing \"{}\" has {} lines of code (max: {}). Consider splitting it into smaller files.",
-                    String::from_utf8_lossy(name), loc, self.settings.max_loc
-                );
-                violations.push(self.new_violation(file, suggestion, span));
+                let message = Message::new(
+                    "E0025:file-too-long",
+                    "File containing \"{name}\" has {loc} lines of code (max: {max}). Consider splitting it into smaller files.",
+                )
+                .arg("name", String::from_utf8_lossy(name).to_string())
+                .arg("loc", loc.to_string())
+                .arg("max", self.settings.max_loc.to_string());
+                violations.push(self.new_violation(file, message, span));
             }
         }
 

--- a/src/rules/e26.rs
+++ b/src/rules/e26.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 
 pub(crate) static CODE: &str = "E0026";
 static DESCRIPTION: &str = "Comment Ratio";
@@ -67,21 +67,23 @@ impl crate::rules::Rule for Rule {
             let ratio = comment_lines as f64 / total_relevant as f64;
 
             if ratio < self.settings.min_ratio {
-                let suggestion = format!(
-                    "Class \"{}\" has a comment ratio of {:.1}% (min: {}%). Add more documentation.",
-                    String::from_utf8_lossy(class.name.value),
-                    ratio * 100.0,
-                    self.settings.min_ratio * 100.0
-                );
-                violations.push(self.new_violation(file, suggestion, class.span()));
+                let message = Message::new(
+                    "E0026:undercommented",
+                    "Class \"{name}\" has a comment ratio of {ratio}% (min: {min}%). Add more documentation.",
+                )
+                .arg("name", String::from_utf8_lossy(class.name.value).to_string())
+                .arg("ratio", format!("{:.1}", ratio * 100.0))
+                .arg("min", format!("{}", self.settings.min_ratio * 100.0));
+                violations.push(self.new_violation(file, message, class.span()));
             } else if ratio > self.settings.max_ratio {
-                let suggestion = format!(
-                    "Class \"{}\" has a comment ratio of {:.1}% (max: {}%). Too many comments may indicate unclear code.",
-                    String::from_utf8_lossy(class.name.value),
-                    ratio * 100.0,
-                    self.settings.max_ratio * 100.0
-                );
-                violations.push(self.new_violation(file, suggestion, class.span()));
+                let message = Message::new(
+                    "E0026:overcommented",
+                    "Class \"{name}\" has a comment ratio of {ratio}% (max: {max}%). Too many comments may indicate unclear code.",
+                )
+                .arg("name", String::from_utf8_lossy(class.name.value).to_string())
+                .arg("ratio", format!("{:.1}", ratio * 100.0))
+                .arg("max", format!("{}", self.settings.max_ratio * 100.0));
+                violations.push(self.new_violation(file, message, class.span()));
             }
         }
 
@@ -147,14 +149,14 @@ mod tests {
     fn undercommented() {
         let violations = analyze_file_for_rule("e26/undercommented.php", CODE);
         assert!(violations.len().gt(&0));
-        assert!(violations[0].suggestion.contains("10%"));
+        assert!(violations[0].message.render().contains("10%"));
     }
 
     #[test]
     fn overcommented() {
         let violations = analyze_file_for_rule("e26/overcommented.php", CODE);
         assert!(violations.len().gt(&0));
-        assert!(violations[0].suggestion.contains("50%"));
+        assert!(violations[0].message.render().contains("50%"));
     }
 
     #[test]

--- a/src/rules/e27.rs
+++ b/src/rules/e27.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 use crate::rules::Rule as RuleTrait;
 
 pub(crate) static CODE: &str = "E0027";
@@ -51,12 +51,16 @@ impl Rule {
         }
 
         if method_count > self.settings.max_methods && field_count > self.settings.max_fields {
-            let suggestion = format!(
-                "\"{}\" is a potential God Class: {} methods and {} fields (max: {} methods, {} fields). Consider splitting it into multiple types with single responsibilities.",
-                name, method_count, field_count,
-                self.settings.max_methods, self.settings.max_fields
-            );
-            violations.push(self.new_violation(file, suggestion, span));
+            let message = Message::new(
+                "E0027:god-class",
+                "\"{name}\" is a potential God Class: {method_count} methods and {field_count} fields (max: {max_methods} methods, {max_fields} fields). Consider splitting it into multiple types with single responsibilities.",
+            )
+            .arg("name", name.to_string())
+            .arg("method_count", method_count.to_string())
+            .arg("field_count", field_count.to_string())
+            .arg("max_methods", self.settings.max_methods.to_string())
+            .arg("max_fields", self.settings.max_fields.to_string());
+            violations.push(self.new_violation(file, message, span));
         }
     }
 }
@@ -111,7 +115,7 @@ mod tests {
     fn god_class() {
         let violations = analyze_file_for_rule("e27/god_class.php", CODE);
         assert!(violations.len().gt(&0));
-        assert!(violations[0].suggestion.contains("GodClass"));
+        assert!(violations[0].message.render().contains("GodClass"));
     }
 
     #[test]

--- a/src/rules/e28.rs
+++ b/src/rules/e28.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 use crate::rules::Rule as RuleTrait;
 
 pub(crate) static CODE: &str = "E0028";
@@ -69,21 +69,25 @@ impl Rule {
         let real_methods = total_methods - accessor_count - if has_constructor { 1 } else { 0 };
 
         if real_methods == 0 && total_methods >= self.settings.min_methods {
-            let suggestion = format!(
-                "\"{}\" is a Data Class: {} fields but no behavior beyond getters and setters. Add domain logic or consider using a value object.",
-                name, field_count
-            );
-            violations.push(self.new_violation(file, suggestion, span));
+            let message = Message::new(
+                "E0028:data-class",
+                "\"{name}\" is a Data Class: {field_count} fields but no behavior beyond getters and setters. Add domain logic or consider using a value object.",
+            )
+            .arg("name", name.to_string())
+            .arg("field_count", field_count.to_string());
+            violations.push(self.new_violation(file, message, span));
         } else if total_methods > 0 {
             let accessor_ratio = accessor_count as f64 / total_methods as f64;
             if accessor_ratio >= self.settings.max_getter_setter_ratio && field_count > 0 {
-                let suggestion = format!(
-                    "\"{}\" is a potential Data Class: {} fields, {:.0}% of methods are accessors (max: {:.0}%). Consider encapsulating behavior.",
-                    name, field_count,
-                    accessor_ratio * 100.0,
-                    self.settings.max_getter_setter_ratio * 100.0
-                );
-                violations.push(self.new_violation(file, suggestion, span));
+                let message = Message::new(
+                    "E0028:potential-data-class",
+                    "\"{name}\" is a potential Data Class: {field_count} fields, {accessor_pct}% of methods are accessors (max: {max_pct}%). Consider encapsulating behavior.",
+                )
+                .arg("name", name.to_string())
+                .arg("field_count", field_count.to_string())
+                .arg("accessor_pct", format!("{:.0}", accessor_ratio * 100.0))
+                .arg("max_pct", format!("{:.0}", self.settings.max_getter_setter_ratio * 100.0));
+                violations.push(self.new_violation(file, message, span));
             }
         }
     }

--- a/src/rules/e29.rs
+++ b/src/rules/e29.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 use crate::rules::Rule as RuleTrait;
 
 pub(crate) static CODE: &str = "E0029";
@@ -88,19 +88,25 @@ impl RuleTrait for Rule {
             let (fan_out, fan_in) = self.compute_fan_in_out(&class_name, &index);
 
             if fan_out > self.settings.max_fan_out {
-                let suggestion = format!(
-                    "Class \"{}\" has fan-out of {} (max: {}). It depends on too many other classes — consider reducing dependencies.",
-                    class_name, fan_out, self.settings.max_fan_out
-                );
-                violations.push(self.new_violation(file, suggestion, class.span()));
+                let message = Message::new(
+                    "E0029:fan-out",
+                    "Class \"{class_name}\" has fan-out of {fan_out} (max: {max_fan_out}). It depends on too many other classes — consider reducing dependencies.",
+                )
+                .arg("class_name", class_name.to_string())
+                .arg("fan_out", fan_out.to_string())
+                .arg("max_fan_out", self.settings.max_fan_out.to_string());
+                violations.push(self.new_violation(file, message, class.span()));
             }
 
             if fan_in > self.settings.max_fan_in {
-                let suggestion = format!(
-                    "Class \"{}\" has fan-in of {} (max: {}). Too many classes depend on it — consider splitting or stabilizing its interface.",
-                    class_name, fan_in, self.settings.max_fan_in
-                );
-                violations.push(self.new_violation(file, suggestion, class.span()));
+                let message = Message::new(
+                    "E0029:fan-in",
+                    "Class \"{class_name}\" has fan-in of {fan_in} (max: {max_fan_in}). Too many classes depend on it — consider splitting or stabilizing its interface.",
+                )
+                .arg("class_name", class_name.to_string())
+                .arg("fan_in", fan_in.to_string())
+                .arg("max_fan_in", self.settings.max_fan_in.to_string());
+                violations.push(self.new_violation(file, message, class.span()));
             }
         }
 
@@ -650,7 +656,7 @@ mod tests {
     fn high_fan_out() {
         let violations = analyze_file_for_rule("e29/high_fan_out.php", CODE);
         assert!(violations.len().gt(&0));
-        assert!(violations[0].suggestion.contains("fan-out"));
+        assert!(violations[0].message.render().contains("fan-out"));
     }
 
     #[test]

--- a/src/rules/e3.rs
+++ b/src/rules/e3.rs
@@ -2,7 +2,7 @@ use mago_span::HasSpan;
 use mago_syntax::ast::{ClassLikeMember, Modifier, Sequence, Statement};
 
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 
 pub struct Rule {}
 
@@ -36,11 +36,15 @@ impl crate::rules::Rule for Rule {
             for member in members.iter() {
                 if let ClassLikeMember::Method(method) = member {
                     if !self.has_visibility_modifier(&method.modifiers) {
-                        let suggestion = format!(
-                            "Method name \"{}\" should be declared with a visibility modifier.",
-                            String::from_utf8_lossy(method.name.value)
+                        let message = Message::new(
+                            "E0003:method-missing-visibility",
+                            "Method name \"{name}\" should be declared with a visibility modifier.",
+                        )
+                        .arg(
+                            "name",
+                            String::from_utf8_lossy(method.name.value).to_string(),
                         );
-                        violations.push(self.new_violation(file, suggestion, method.span()));
+                        violations.push(self.new_violation(file, message, method.span()));
                     }
                 }
             }
@@ -74,7 +78,7 @@ mod tests {
 
         assert!(violations.len().gt(&0));
         assert_eq!(
-            violations.first().unwrap().suggestion,
+            violations.first().unwrap().message.render(),
             "Method name \"methodWithoutModifier\" should be declared with a visibility modifier."
                 .to_string()
         );
@@ -86,7 +90,7 @@ mod tests {
 
         assert!(violations.len().gt(&0));
         assert_eq!(
-            violations.first().unwrap().suggestion,
+            violations.first().unwrap().message.render(),
             "Method name \"__construct\" should be declared with a visibility modifier."
                 .to_string()
         );

--- a/src/rules/e30.rs
+++ b/src/rules/e30.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 use crate::rules::e9::calculate_complexity;
 use crate::rules::Rule as RuleTrait;
 
@@ -49,12 +49,16 @@ impl Rule {
                     let density = complexity as f64 / loc as f64;
 
                     if density > self.settings.max_density {
-                        let suggestion = format!(
-                            "Method \"{}\" has complexity density of {:.2} (max: {:.2}). Complexity {} in {} lines. Consider simplifying the logic.",
-                            String::from_utf8_lossy(method.name.value), density, self.settings.max_density,
-                            complexity, loc
-                        );
-                        violations.push(self.new_violation(file, suggestion, method.span()));
+                        let message = Message::new(
+                            "E0030:complexity-density",
+                            "Method \"{name}\" has complexity density of {density} (max: {max_density}). Complexity {complexity} in {loc} lines. Consider simplifying the logic.",
+                        )
+                        .arg("name", String::from_utf8_lossy(method.name.value).to_string())
+                        .arg("density", format!("{:.2}", density))
+                        .arg("max_density", format!("{:.2}", self.settings.max_density))
+                        .arg("complexity", complexity.to_string())
+                        .arg("loc", loc.to_string());
+                        violations.push(self.new_violation(file, message, method.span()));
                     }
                 }
             }
@@ -112,7 +116,7 @@ mod tests {
     fn dense_method() {
         let violations = analyze_file_for_rule("e30/dense_method.php", CODE);
         assert!(violations.len().gt(&0));
-        assert!(violations[0].suggestion.contains("denseMethod"));
+        assert!(violations[0].message.render().contains("denseMethod"));
     }
 
     #[test]

--- a/src/rules/e4.rs
+++ b/src/rules/e4.rs
@@ -2,7 +2,7 @@ use mago_span::HasSpan;
 use mago_syntax::ast::{ClassLikeMember, Statement};
 
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 use crate::rules::Rule as RuleTrait;
 
 pub struct Rule {}
@@ -32,8 +32,10 @@ impl crate::rules::Rule for Rule {
                     let name = item.name.value;
                     let name_str = std::str::from_utf8(name).unwrap_or_default();
                     if name_str != name_str.to_uppercase() {
-                        let suggestion = format!("The constant {} should be uppercase.", name_str);
-                        violations.push(self.new_violation(file, suggestion, item.name.span()));
+                        let message =
+                            Message::new("E0004:constant-not-uppercase", "The constant {name} should be uppercase.")
+                                .arg("name", name_str.to_string());
+                        violations.push(self.new_violation(file, message, item.name.span()));
                     }
                 }
             }
@@ -66,11 +68,13 @@ fn collect_member_constants(
                 let name = item.name.value;
                 let name_str = std::str::from_utf8(name).unwrap_or_default();
                 if name_str != name_str.to_uppercase() {
-                    let suggestion = format!("The constant {} should be uppercase.", name_str);
+                    let message =
+                        Message::new("E0004:constant-not-uppercase", "The constant {name} should be uppercase.")
+                            .arg("name", name_str.to_string());
                     violations.push(RuleTrait::new_violation(
                         rule,
                         file,
-                        suggestion,
+                        message,
                         item.name.span(),
                     ));
                 }
@@ -91,7 +95,7 @@ mod tests {
 
         assert!(violations.len().gt(&0));
         assert_eq!(
-            violations.first().unwrap().suggestion,
+            violations.first().unwrap().message.render(),
             "The constant TeST should be uppercase.".to_string()
         );
     }

--- a/src/rules/e5.rs
+++ b/src/rules/e5.rs
@@ -2,7 +2,7 @@ use mago_span::HasSpan;
 use mago_syntax::ast::Statement;
 
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 
 pub(crate) static CODE: &str = "E0005";
 static DESCRIPTION: &str = "Capitalized class name";
@@ -30,8 +30,12 @@ impl crate::rules::Rule for Rule {
             let name_str = std::str::from_utf8(name).unwrap_or_default();
             if let Some(first) = name_str.chars().next() {
                 if !first.is_uppercase() {
-                    let suggestion = format!("The class name {} is not capitalized. The first letter of the name of the class should be in uppercase.", name_str);
-                    violations.push(self.new_violation(file, suggestion, class.name.span()))
+                    let message = Message::new(
+                        "E0005:class-name-not-capitalized",
+                        "The class name {name} is not capitalized. The first letter of the name of the class should be in uppercase.",
+                    )
+                    .arg("name", name_str.to_string());
+                    violations.push(self.new_violation(file, message, class.name.span()))
                 }
             }
         };
@@ -52,7 +56,7 @@ mod tests {
 
         assert!(violations.len().gt(&0));
         assert_eq!(
-            violations.first().unwrap().suggestion,
+            violations.first().unwrap().message.render(),
             "The class name nonCapitalized is not capitalized. The first letter of the name of the class should be in uppercase.".to_string()
         );
     }

--- a/src/rules/e6.rs
+++ b/src/rules/e6.rs
@@ -2,7 +2,7 @@ use mago_span::HasSpan;
 use mago_syntax::ast::{ClassLikeMember, Modifier, Property, Statement};
 
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 
 pub(crate) static CODE: &str = "E0006";
 static DESCRIPTION: &str = "Property modifiers";
@@ -35,9 +35,12 @@ impl crate::rules::Rule for Rule {
                             .map(|v| String::from_utf8_lossy(v.name).into_owned())
                             .collect();
 
-                        let suggestion =
-                            format!("The variables {} have no modifier.", names.join(", "));
-                        violations.push(self.new_violation(file, suggestion, property.span()));
+                        let message = Message::new(
+                            "E0006:property-missing-modifier",
+                            "The variables {names} have no modifier.",
+                        )
+                        .arg("names", names.join(", "));
+                        violations.push(self.new_violation(file, message, property.span()));
                     }
                 }
             }
@@ -70,7 +73,7 @@ mod tests {
 
         assert!(violations.len().gt(&0));
         assert_eq!(
-            violations.first().unwrap().suggestion,
+            violations.first().unwrap().message.render(),
             "The variables $var have no modifier.".to_string()
         );
     }

--- a/src/rules/e7.rs
+++ b/src/rules/e7.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 
 pub(crate) static CODE: &str = "E0007";
 static DESCRIPTION: &str = "Method parameters count";
@@ -62,18 +62,21 @@ impl crate::rules::Rule for Rule {
                         if self.settings.check_constructor
                             && parameters_count > self.settings.max_parameters as usize
                         {
-                            let suggestion = format!(
-                                "Constructor has too many parameters. More than {} parameters is considered a too much.",
-                                self.settings.max_parameters
-                            );
-                            violations.push(self.new_violation(file, suggestion, method.span()));
+                            let message = Message::new(
+                                "E0007:constructor-too-many-parameters",
+                                "Constructor has too many parameters. More than {max} parameters is considered a too much.",
+                            )
+                            .arg("max", self.settings.max_parameters.to_string());
+                            violations.push(self.new_violation(file, message, method.span()));
                         }
                     } else if parameters_count > self.settings.max_parameters as usize {
-                        let suggestion = format!(
-                            "Method {} has too many parameters. More than {} parameters is considered a too much.",
-                            String::from_utf8_lossy(name), self.settings.max_parameters
-                        );
-                        violations.push(self.new_violation(file, suggestion, method.span()));
+                        let message = Message::new(
+                            "E0007:method-too-many-parameters",
+                            "Method {name} has too many parameters. More than {max} parameters is considered a too much.",
+                        )
+                        .arg("name", String::from_utf8_lossy(name).to_string())
+                        .arg("max", self.settings.max_parameters.to_string());
+                        violations.push(self.new_violation(file, message, method.span()));
                     }
                 }
             }
@@ -95,7 +98,7 @@ mod tests {
 
         assert!(violations.len().gt(&0));
         assert_eq!(
-            violations.first().unwrap().suggestion,
+            violations.first().unwrap().message.render(),
             "Method test has too many parameters. More than 8 parameters is considered a too much."
                 .to_string()
         );

--- a/src/rules/e8.rs
+++ b/src/rules/e8.rs
@@ -2,7 +2,7 @@ use mago_span::HasSpan;
 use mago_syntax::ast::{ClassLikeMember, MethodBody, Statement};
 
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 
 pub(crate) static CODE: &str = "E0008";
 static DESCRIPTION: &str = "Return type signature";
@@ -37,11 +37,12 @@ impl crate::rules::Rule for Rule {
                             .any(|s| matches!(s, Statement::Return(_)));
 
                         if has_return && method.return_type_hint.is_none() {
-                            let suggestion = format!(
-                                "The method {} has a return statement but it has no return type signature.",
-                                String::from_utf8_lossy(method.name.value)
-                            );
-                            violations.push(self.new_violation(file, suggestion, method.span()));
+                            let message = Message::new(
+                                "E0008:missing-return-type",
+                                "The method {name} has a return statement but it has no return type signature.",
+                            )
+                            .arg("name", String::from_utf8_lossy(method.name.value).to_string());
+                            violations.push(self.new_violation(file, message, method.span()));
                         }
                     }
                 }
@@ -64,7 +65,7 @@ mod tests {
 
         assert!(violations.len().gt(&0));
         assert_eq!(
-            violations.first().unwrap().suggestion,
+            violations.first().unwrap().message.render(),
             "The method test has a return statement but it has no return type signature."
                 .to_string()
         );

--- a/src/rules/e9.rs
+++ b/src/rules/e9.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 
 pub(crate) static CODE: &str = "E0009";
 static DESCRIPTION: &str = "Cyclomatic complexity";
@@ -59,12 +59,13 @@ impl crate::rules::Rule for Rule {
                         let complexity = 1 + calculate_complexity(&block.statements);
 
                         if complexity > self.settings.max_complexity {
-                            let suggestion = format!(
-                                "The body of {} method has {} complexity. Make it easier to understand.",
-                                String::from_utf8_lossy(method.name.value),
-                                complexity,
-                            );
-                            violations.push(self.new_violation(file, suggestion, method.span()));
+                            let message = Message::new(
+                                "E0009:high-cyclomatic-complexity",
+                                "The body of {name} method has {complexity} complexity. Make it easier to understand.",
+                            )
+                            .arg("name", String::from_utf8_lossy(method.name.value).to_string())
+                            .arg("complexity", complexity.to_string());
+                            violations.push(self.new_violation(file, message, method.span()));
                         }
                     }
                 }
@@ -201,7 +202,7 @@ mod tests {
 
         assert!(violations.len().gt(&0));
         assert_eq!(
-            violations.first().unwrap().suggestion,
+            violations.first().unwrap().message.render(),
             "The body of complexMethod method has 11 complexity. Make it easier to understand."
                 .to_string()
         );

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 
 use crate::config::Config;
 use crate::file::File;
-use crate::results::Violation;
+use crate::results::{Message, Violation};
 pub mod e0;
 pub mod e1;
 pub mod e10;
@@ -112,7 +112,7 @@ pub trait Rule {
 
     fn validate(&self, file: &File<'_>, statement: &Statement<'_>) -> Vec<Violation>;
 
-    fn new_violation(&self, file: &File<'_>, suggestion: String, span: Span) -> Violation {
+    fn new_violation(&self, file: &File<'_>, message: Message, span: Span) -> Violation {
         let start_line = file.line_number(span.start.offset);
         let start_column = file.column_number(span.start.offset);
         let end_line = file.line_number(span.end.offset);
@@ -127,7 +127,7 @@ pub trait Rule {
         Violation {
             rule: self.get_code(),
             line,
-            suggestion,
+            message,
             start_line,
             start_column,
             end_line,


### PR DESCRIPTION
Replaces the free-form `Violation.suggestion` string with a structured `Message`
type, groundwork for a future baseline feature that needs a stable key per baseline
entry. Changes:
- New `Message { id, template, args }` in `src/results.rs`:
  - `id` - stable slug per message (e.g. `E0009:high-cyclomatic-complexity`),
    intended as a key. Reword the text freely without changing it.
  - `template` + `args` - `{placeholder}` text and its values; `render()` produces
    the displayed string.
  - `#[non_exhaustive]` + builder, so future fields (severity, fix data) are additive.
- `new_violation` now takes a `Message` instead of a `String`.
- All 30 rules converted: each message gets a stable id; dynamic messages keep
  exact output via `.arg(...)` (float specifiers preserved).

**Output formats**

- `text`, `sarif`, `codeclimate` - unchanged, render to the same string as before.
- `json` - additive, not breaking: keeps a flat rendered `suggestion` field for
  existing consumers and adds the structured `message` object alongside it.

**Notes**

- No user-facing behavior change beyond the additive `json` field.
- Contributor docs (`docs/adding_new_rule.md`) updated to show the `Message` pattern
  and the id convention.
- 225 tests pass; clippy clean (remaining warnings are pre-existing in e15/e20/tests).
- I know this is a big PR, but it is necessary to implement baseline: We need stable key 
  that we can group by.