### PR TITLE
Relax default configuration thresholds

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+echo "Running tests before push..."
+
+cargo test 2>&1
+
+echo "All tests passed."

--- a/phanalist.yaml
+++ b/phanalist.yaml
@@ -6,7 +6,7 @@ rules:
   E0010:
     max_paths: 200
   E0007:
-    check_constructor: false
+    check_constructor: true
     max_parameters: 8
   E0012:
     exclude_namespaces: []
@@ -16,11 +16,11 @@ rules:
     reset_interfaces:
     - ResetInterface
   E0024:
-    max_loc: 30
+    max_loc: 50
   E0025:
     max_loc: 500
   E0026:
-    min_ratio: 0.1
+    min_ratio: 0.05
     max_ratio: 0.5
   E0027:
     max_methods: 15

--- a/src/rules/e24.rs
+++ b/src/rules/e24.rs
@@ -17,7 +17,7 @@ pub struct Settings {
 
 impl Default for Settings {
     fn default() -> Self {
-        Settings { max_loc: 30 }
+        Settings { max_loc: 50 }
     }
 }
 

--- a/src/rules/e26.rs
+++ b/src/rules/e26.rs
@@ -149,7 +149,7 @@ mod tests {
     fn undercommented() {
         let violations = analyze_file_for_rule("e26/undercommented.php", CODE);
         assert!(violations.len().gt(&0));
-        assert!(violations[0].message.render().contains("10%"));
+        assert!(violations[0].message.render().contains("5%"));
     }
 
     #[test]

--- a/src/rules/e26.rs
+++ b/src/rules/e26.rs
@@ -18,7 +18,7 @@ pub struct Settings {
 impl Default for Settings {
     fn default() -> Self {
         Settings {
-            min_ratio: 0.1,
+            min_ratio: 0.05,
             max_ratio: 0.5,
         }
     }

--- a/src/rules/e7.rs
+++ b/src/rules/e7.rs
@@ -108,7 +108,12 @@ mod tests {
     fn constructor_max_params() {
         let violations = analyze_file_for_rule("e7/constructor_max_params.php", CODE);
 
-        assert!(violations.len().eq(&0));
+        assert!(violations.len().gt(&0));
+        assert_eq!(
+            violations.first().unwrap().message.render(),
+            "Constructor has too many parameters. More than 8 parameters is considered a too much."
+                .to_string()
+        );
     }
 
     #[test]

--- a/src/rules/e7.rs
+++ b/src/rules/e7.rs
@@ -18,7 +18,7 @@ pub struct Settings {
 impl Default for Settings {
     fn default() -> Self {
         Settings {
-            check_constructor: false,
+            check_constructor: true,
             max_parameters: 8,
         }
     }

--- a/src/rules/examples/e24/long_method.php
+++ b/src/rules/examples/e24/long_method.php
@@ -37,5 +37,26 @@ class LongMethodExample
         $cc = 29;
         $dd = 30;
         $ee = 31;
+        $ff = 32;
+        $gg = 33;
+        $hh = 34;
+        $ii = 35;
+        $jj = 36;
+        $kk = 37;
+        $ll = 38;
+        $mm = 39;
+        $nn = 40;
+        $oo = 41;
+        $pp = 42;
+        $qq = 43;
+        $rr = 44;
+        $ss = 45;
+        $tt = 46;
+        $uu = 47;
+        $vv = 48;
+        $ww = 49;
+        $xx = 50;
+        $yy = 51;
+        $zz = 52;
     }
 }


### PR DESCRIPTION
- E0007: enable constructor parameter checking (check_constructor: true)
- E0024: raise method LOC limit from 30 to 50
- E0026: lower minimum comment ratio from 0.1 to 0.05